### PR TITLE
feat: advisory mic-lease + multipart send-mutex (per-channel coordination)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import type { DiscordClient, DiscordMessage } from "./discord";
 import { createCache } from "./cache";
 import type { Cache } from "./cache";
 import { initialPoll, startPollingLoop, createLogger, createChannelHealth } from "./poller";
+import { claim, release, status, DEFAULT_TTL, type LeaseKind } from "./mic";
 
 const VERSION = "0.2.0";
 const startTime = Date.now();
@@ -36,6 +37,35 @@ function createHandler(
           misses: stats.misses,
         },
       });
+    }
+
+    // Advisory coordination leases (#14): /lease/{mic|send}/{claim|release|status}
+    const leaseMatch = url.pathname.match(/^\/lease\/(mic|send)\/(claim|release|status)$/);
+    if (leaseMatch) {
+      const kind = leaseMatch[1] as LeaseKind;
+      const action = leaseMatch[2];
+      if (action === "status" && req.method === "GET") {
+        const channel = url.searchParams.get("channel");
+        if (!channel) return Response.json({ error: "channel query param required" }, { status: 400 });
+        return Response.json({ kind, channel, lease: status(kind, channel) });
+      }
+      if ((action === "claim" || action === "release") && req.method === "POST") {
+        const body = (await req.json().catch(() => ({}))) as {
+          channel?: string;
+          holder?: string;
+          ttl_ms?: number;
+        };
+        if (!body.channel || !body.holder) {
+          return Response.json({ error: "channel and holder are required" }, { status: 400 });
+        }
+        if (action === "claim") {
+          const ttl =
+            typeof body.ttl_ms === "number" && body.ttl_ms > 0 ? body.ttl_ms : DEFAULT_TTL[kind];
+          return Response.json({ kind, channel: body.channel, ...claim(kind, body.channel, body.holder, ttl) });
+        }
+        return Response.json({ kind, channel: body.channel, ...release(kind, body.channel, body.holder) });
+      }
+      return Response.json({ error: "method not allowed" }, { status: 405 });
     }
 
     // GET /api/v10/guilds/{guildId}/channels

--- a/mic.test.ts
+++ b/mic.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { claim, release, status, _resetLeases, DEFAULT_TTL } from "./mic";
+
+const CH = "chan1";
+
+beforeEach(() => _resetLeases());
+
+describe("mic / lease primitive", () => {
+  test("first claim is granted", () => {
+    const r = claim("mic", CH, "babelfish", 1000, 0);
+    expect(r.granted).toBe(true);
+    expect(r.holder).toBe("babelfish");
+    expect(r.expiresAt).toBe(1000);
+  });
+
+  test("a second holder is refused while held", () => {
+    claim("mic", CH, "babelfish", 1000, 0);
+    const r = claim("mic", CH, "neuron", 1000, 500);
+    expect(r.granted).toBe(false);
+    expect(r.holder).toBe("babelfish");
+  });
+
+  test("claim succeeds after the lease expires (no deadlock)", () => {
+    claim("mic", CH, "babelfish", 1000, 0);
+    const r = claim("mic", CH, "neuron", 1000, 1001);
+    expect(r.granted).toBe(true);
+    expect(r.holder).toBe("neuron");
+  });
+
+  test("re-claim by the same holder refreshes the TTL", () => {
+    claim("mic", CH, "babelfish", 1000, 0);
+    const r = claim("mic", CH, "babelfish", 1000, 500);
+    expect(r.granted).toBe(true);
+    expect(r.expiresAt).toBe(1500);
+  });
+
+  test("only the holder may release", () => {
+    claim("mic", CH, "babelfish", 1000, 0);
+    expect(release("mic", CH, "neuron", 100)).toEqual({ released: false, holder: "babelfish" });
+    expect(release("mic", CH, "babelfish", 100)).toEqual({ released: true });
+    // freed → next claimer gets it
+    expect(claim("mic", CH, "neuron", 1000, 200).granted).toBe(true);
+  });
+
+  test("release is idempotent on a free/expired lease", () => {
+    expect(release("mic", CH, "whoever", 0)).toEqual({ released: true });
+  });
+
+  test("status reflects holder and expiry; null when free/expired", () => {
+    expect(status("mic", CH, 0)).toBeNull();
+    claim("mic", CH, "babelfish", 1000, 0);
+    expect(status("mic", CH, 500)).toEqual({ holder: "babelfish", expiresAt: 1000 });
+    expect(status("mic", CH, 1001)).toBeNull();
+  });
+
+  test("mic and send are independent leases on the same channel", () => {
+    claim("mic", CH, "babelfish", 1000, 0);
+    const r = claim("send", CH, "neuron", 1000, 0);
+    expect(r.granted).toBe(true); // send lease is separate from mic
+  });
+
+  test("default TTLs are sane (mic longer than send)", () => {
+    expect(DEFAULT_TTL.mic).toBeGreaterThan(DEFAULT_TTL.send);
+  });
+});

--- a/mic.ts
+++ b/mic.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-channel advisory coordination leases (#14).
+ *
+ * Two cheap, TTL'd primitives that every agent already reaches through
+ * scream-hole, to tame the "many agents answer at once" chaos:
+ *
+ *  - **mic**: a talking-stick. An agent claims it before answering a team
+ *    question; others see it's taken and hold (keep researching, don't speak).
+ *    Advisory — it serializes the *timing* of a decision the agents already make
+ *    (domain ownership); it does not re-decide who should speak.
+ *  - **send**: a multipart send-mutex. While one agent emits `1/3,2/3,3/3`,
+ *    another's parts can't interleave on the channel.
+ *
+ * Both are leases with a TTL so a crashed/stalled holder auto-frees — they can
+ * never deadlock. State is in-memory (scream-hole is the single shared poller).
+ */
+
+export type LeaseKind = "mic" | "send";
+
+export interface Lease {
+  holder: string;
+  expiresAt: number; // epoch ms
+}
+
+export interface ClaimResult {
+  granted: boolean;
+  holder: string;
+  expiresAt: number;
+}
+
+const leases = new Map<string, Lease>();
+
+function key(kind: LeaseKind, channel: string): string {
+  return `${kind}:${channel}`;
+}
+
+/** For tests: drop all leases. */
+export function _resetLeases(): void {
+  leases.clear();
+}
+
+/**
+ * Claim a lease. Granted if the lease is free, expired, or already held by the
+ * same holder (a re-claim refreshes the TTL). Otherwise returns the current
+ * holder without changing anything.
+ */
+export function claim(
+  kind: LeaseKind,
+  channel: string,
+  holder: string,
+  ttlMs: number,
+  now: number = Date.now(),
+): ClaimResult {
+  const k = key(kind, channel);
+  const cur = leases.get(k);
+  if (cur && cur.expiresAt > now && cur.holder !== holder) {
+    return { granted: false, holder: cur.holder, expiresAt: cur.expiresAt };
+  }
+  const lease: Lease = { holder, expiresAt: now + ttlMs };
+  leases.set(k, lease);
+  return { granted: true, holder, expiresAt: lease.expiresAt };
+}
+
+/**
+ * Release a lease. Succeeds (idempotently) if free/expired. Refuses if held by
+ * someone else — only the holder may release.
+ */
+export function release(
+  kind: LeaseKind,
+  channel: string,
+  holder: string,
+  now: number = Date.now(),
+): { released: boolean; holder?: string } {
+  const k = key(kind, channel);
+  const cur = leases.get(k);
+  if (!cur || cur.expiresAt <= now) return { released: true };
+  if (cur.holder !== holder) return { released: false, holder: cur.holder };
+  leases.delete(k);
+  return { released: true };
+}
+
+/** Current holder of a lease, or null if free/expired. */
+export function status(
+  kind: LeaseKind,
+  channel: string,
+  now: number = Date.now(),
+): Lease | null {
+  const cur = leases.get(key(kind, channel));
+  if (!cur || cur.expiresAt <= now) return null;
+  return { holder: cur.holder, expiresAt: cur.expiresAt };
+}
+
+/** Default lease TTLs (ms). Generous enough to cover a turn; short enough to self-heal. */
+export const DEFAULT_TTL: Record<LeaseKind, number> = {
+  mic: 90_000,
+  send: 30_000,
+};


### PR DESCRIPTION
## Summary
Two cheap, TTL'd per-channel leases in scream-hole to tame "many agents answer at once": a **mic** (talking-stick — claim before speaking; others hold) and a **multipart send-mutex** (parts can't interleave). Both auto-free on TTL → no deadlock. Reframe: this serializes the *timing* of the domain-ownership decision agents already make well — it does NOT re-decide who speaks (no bid/auction).

## Changes
- `mic.ts` — lease primitive: `claim`/`release`/`status` (injectable clock), `mic`+`send` kinds, holder-only release, re-claim refreshes TTL.
- `index.ts` — routes `POST /lease/{mic|send}/{claim|release}` + `GET /lease/{mic|send}/status?channel=`.

## Linked Issues
Closes #14

## Test Plan
- `bun test mic.test.ts` → 9/0 (exclusivity, TTL expiry/no-deadlock, holder-only release, re-claim refresh, mic/send independence); `validate.sh` → 72/0; tsc clean.

## Follow-up
The agent-facing convention (when to claim vs defer) is a paired disc-skill change in claudecode-workflow — this PR is the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)