### PR TITLE
chore(release): set version to 1.1.0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import type { Cache } from "./cache";
 import { initialPoll, startPollingLoop, createLogger, createChannelHealth } from "./poller";
 import { claim, release, status, DEFAULT_TTL, type LeaseKind } from "./mic";
 
-const VERSION = "0.3.0";
+const VERSION = "1.1.0";
 const startTime = Date.now();
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scream-hole",
-  "version": "0.3.0",
+  "version": "1.1.0",
   "description": "Discord REST API caching proxy — polls once, serves many",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

The in-repo version fields were historically stale; the authoritative version is the git/ghcr tag (`v1.0.0` is the real release at commit `ea61291`). Recent #16/#18 "unify" synced to the stale code value (`0.3.0`) instead of the tag line. Correct the code **up** to the real line.

## Changes

- `package.json` `version` and `index.ts` `VERSION` → `1.1.0`.
- `1.0.0` + #16 (cache 404 fix) + #18 (creation-POST proxying + rate-limit header forwarding, a feature) = minor bump → `1.1.0`.
- Monotonic lineage `0.2.1 → 1.0.0 → 1.1.0`; no backwards/downgrade jump for consumers.

## Linked Issues

Closes #20

## Test Plan

- `./scripts/ci/validate.sh` → lint + shellcheck + `bun test`: 89 pass / 0 fail. The `/health` test asserts `body.version === VERSION`, so it stays in sync.
- Code review (precheck): no findings — only the two version strings changed; `release.yml` derives the image tag from the git tag (no literal to drift).

## Release

After merge, `v1.1.0` is tagged on the merge commit; `release.yml` builds and pushes `ghcr.io/wave-engineering/scream-hole:1.1.0` + `:latest`. This is the release (image publish), not the deploy — the swarm `docker service update --force` is a separate, gated step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)