### PR TITLE
feat(proxy): forward Discord webhook routes (list/create/execute)

### DIFF
--- a/discord.ts
+++ b/discord.ts
@@ -4,6 +4,19 @@
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 
+/**
+ * Mask secrets in a request path before logging. The webhook-execute path
+ * `/webhooks/{id}/{token}` carries a reusable credential in the token segment
+ * (and possibly the query), so redact it to `/webhooks/{id}/***`. Other paths
+ * are returned unchanged (their query is useful for debugging and non-secret).
+ */
+function redactPathForLog(path: string): string {
+  if (path.startsWith("/webhooks/")) {
+    return path.replace(/^(\/webhooks\/[^/]+\/)[^/?]+.*$/, "$1***");
+  }
+  return path;
+}
+
 export interface DiscordChannel {
   id: string;
   type: number;
@@ -49,6 +62,26 @@ export interface DiscordClient {
   /** Forward a create-thread POST to `/channels/{channelId}/threads`. */
   createThread(
     channelId: string,
+    body: BodyInit,
+    contentType: string,
+  ): Promise<SendMessageResponse>;
+  /** Forward a live GET to `/channels/{channelId}/webhooks` (body verbatim, incl. tokens). */
+  listWebhooks(channelId: string): Promise<SendMessageResponse>;
+  /** Forward a create-webhook POST to `/channels/{channelId}/webhooks`. */
+  createWebhook(
+    channelId: string,
+    body: BodyInit,
+    contentType: string,
+  ): Promise<SendMessageResponse>;
+  /**
+   * Forward a webhook-execute POST to `/webhooks/{webhookId}/{token}{search}`.
+   * `search` is the verbatim query string (e.g. `?wait=true`), including the
+   * leading `?`, or empty.
+   */
+  executeWebhook(
+    webhookId: string,
+    token: string,
+    search: string,
     body: BodyInit,
     contentType: string,
   ): Promise<SendMessageResponse>;
@@ -108,7 +141,7 @@ export function createDiscordClient(
       const retryAfter = rawRetryAfter !== null ? Number(rawRetryAfter) : 1;
       const waitMs = Math.max(0, retryAfter) * 1000;
       console.warn(
-        `[discord] 429 rate limited on ${method} ${path} — retrying after ${waitMs}ms`,
+        `[discord] 429 rate limited on ${method} ${redactPathForLog(path)} — retrying after ${waitMs}ms`,
       );
       await new Promise((resolve) => setTimeout(resolve, waitMs));
       // Retry once after waiting
@@ -118,18 +151,8 @@ export function createDiscordClient(
     return res;
   }
 
-  /**
-   * Forward a POST to an arbitrary Discord path and return the raw outcome
-   * (status + parsed body) without throwing. Shared by all write pass-throughs
-   * (message send, channel creation, thread creation).
-   */
-  async function forwardPost(
-    path: string,
-    body: BodyInit,
-    contentType: string,
-  ): Promise<SendMessageResponse> {
-    const res = await discordFetch(path, { method: "POST", body, contentType });
-
+  /** Parse a Discord Response into the verbatim raw outcome (status + body), no throw. */
+  async function parseForward(res: Response): Promise<SendMessageResponse> {
     const rawText = await res.text();
     let responseBody: unknown;
     try {
@@ -143,6 +166,30 @@ export function createDiscordClient(
       headers: res.headers,
       body: responseBody,
     };
+  }
+
+  /**
+   * Forward a POST to an arbitrary Discord path and return the raw outcome
+   * without throwing. Shared by all write pass-throughs (message send, channel
+   * creation, thread creation, webhook create/execute).
+   */
+  async function forwardPost(
+    path: string,
+    body: BodyInit,
+    contentType: string,
+  ): Promise<SendMessageResponse> {
+    return parseForward(
+      await discordFetch(path, { method: "POST", body, contentType }),
+    );
+  }
+
+  /**
+   * Forward a live GET to an arbitrary Discord path and return the raw outcome
+   * (body verbatim — no filtering). Used for non-cacheable reads like the
+   * webhook list, whose token fields must pass through untouched.
+   */
+  async function forwardGet(path: string): Promise<SendMessageResponse> {
+    return parseForward(await discordFetch(path, { method: "GET" }));
   }
 
   return {
@@ -193,6 +240,28 @@ export function createDiscordClient(
       contentType: string,
     ): Promise<SendMessageResponse> {
       return forwardPost(`/channels/${channelId}/threads`, body, contentType);
+    },
+
+    listWebhooks(channelId: string): Promise<SendMessageResponse> {
+      return forwardGet(`/channels/${channelId}/webhooks`);
+    },
+
+    createWebhook(
+      channelId: string,
+      body: BodyInit,
+      contentType: string,
+    ): Promise<SendMessageResponse> {
+      return forwardPost(`/channels/${channelId}/webhooks`, body, contentType);
+    },
+
+    executeWebhook(
+      webhookId: string,
+      token: string,
+      search: string,
+      body: BodyInit,
+      contentType: string,
+    ): Promise<SendMessageResponse> {
+      return forwardPost(`/webhooks/${webhookId}/${token}${search}`, body, contentType);
     },
   };
 }

--- a/index.ts
+++ b/index.ts
@@ -6,8 +6,16 @@ import type { Cache } from "./cache";
 import { initialPoll, startPollingLoop, createLogger, createChannelHealth } from "./poller";
 import { claim, release, status, DEFAULT_TTL, type LeaseKind } from "./mic";
 
-const VERSION = "1.1.0";
+const VERSION = "1.2.0";
 const startTime = Date.now();
+
+/**
+ * Statuses that MUST have a null body per the Fetch spec — constructing a
+ * `Response` with a non-null body and one of these throws. Discord can return
+ * 204 No Content from a webhook-execute (#23), so the shared write builder
+ * must emit a null body for these (#22).
+ */
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
 /**
  * Discord rate-limit response headers, forwarded verbatim on write pass-throughs
@@ -32,11 +40,17 @@ const RATE_LIMIT_HEADERS = [
  * allowlisted rate-limit headers Discord returned.
  */
 function writeResponse(result: SendMessageResponse): Response {
-  const headers = new Headers({ "Content-Type": "application/json" });
+  const headers = new Headers();
   for (const name of RATE_LIMIT_HEADERS) {
     const value = result.headers.get(name);
     if (value !== null) headers.set(name, value);
   }
+  // Null-body statuses (e.g. a 204 from webhook-execute) must not carry a body,
+  // else the Response constructor throws (#22). Still forward rate-limit headers.
+  if (NULL_BODY_STATUSES.has(result.status)) {
+    return new Response(null, { status: result.status, headers });
+  }
+  headers.set("Content-Type", "application/json");
   return new Response(JSON.stringify(result.body), {
     status: result.status,
     headers,
@@ -257,6 +271,40 @@ function createHandler(
     if (req.method === "POST" && threadsMatch) {
       const channelId = threadsMatch[1];
       return forwardCreate((body, ct) => client!.createThread(channelId, body, ct));
+    }
+
+    // /api/v10/channels/{channelId}/webhooks — webhook list (GET) + create (POST) (#23)
+    const webhooksMatch = url.pathname.match(
+      /^\/api\/v10\/channels\/([^/]+)\/webhooks$/,
+    );
+    if (req.method === "GET" && webhooksMatch) {
+      if (!client) {
+        return Response.json(
+          { error: "Webhook pass-through is not configured (no Discord client)" },
+          { status: 503 },
+        );
+      }
+      // Live, non-cached forward: webhook tokens must not be cached/staled, and
+      // the body (each webhook's `token`) passes through verbatim so consumers
+      // reuse an existing webhook instead of exhausting Discord's per-channel cap.
+      return writeResponse(await client.listWebhooks(webhooksMatch[1]));
+    }
+    if (req.method === "POST" && webhooksMatch) {
+      const channelId = webhooksMatch[1];
+      return forwardCreate((body, ct) => client!.createWebhook(channelId, body, ct));
+    }
+
+    // POST /api/v10/webhooks/{webhookId}/{token} — webhook execute pass-through (#23)
+    // Top-level route (not under /channels). The verbatim query string (e.g.
+    // `?wait=true`) is preserved — disc-server relies on it to get the message back.
+    const webhookExecMatch = url.pathname.match(
+      /^\/api\/v10\/webhooks\/([^/]+)\/([^/]+)$/,
+    );
+    if (req.method === "POST" && webhookExecMatch) {
+      const [, webhookId, token] = webhookExecMatch;
+      return forwardCreate((body, ct) =>
+        client!.executeWebhook(webhookId, token, url.search, body, ct),
+      );
     }
 
     return Response.json({ error: "not found" }, { status: 404 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scream-hole",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Discord REST API caching proxy — polls once, serves many",
   "type": "module",
   "main": "index.ts",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -288,8 +288,8 @@ describe("POST /api/v10/channels/{channelId}/messages", () => {
    */
   function mockClient(
     sendResponse: SendMessageResponse,
-  ): DiscordClient & { captured: { channelId: string; body: string; contentType: string } } {
-    const captured = { channelId: "", body: "", contentType: "" };
+  ): DiscordClient & { captured: { channelId: string; body: string; contentType: string; search: string } } {
+    const captured = { channelId: "", body: "", contentType: "", search: "" };
     const record = (id: string, body: BodyInit, contentType: string) => {
       captured.channelId = id;
       if (body instanceof ArrayBuffer) {
@@ -317,6 +317,19 @@ describe("POST /api/v10/channels/{channelId}/messages", () => {
       },
       async createThread(channelId, body, contentType) {
         record(channelId, body, contentType);
+        return sendResponse;
+      },
+      async listWebhooks(channelId) {
+        captured.channelId = channelId;
+        return sendResponse;
+      },
+      async createWebhook(channelId, body, contentType) {
+        record(channelId, body, contentType);
+        return sendResponse;
+      },
+      async executeWebhook(webhookId, token, search, body, contentType) {
+        record(webhookId, body, contentType);
+        captured.search = search;
         return sendResponse;
       },
     };
@@ -636,6 +649,137 @@ describe("POST /api/v10/channels/{channelId}/messages", () => {
       expect(res.status).toBe(429);
       expect(res.headers.get("Retry-After")).toBe("3");
       expect(res.headers.get("Set-Cookie")).toBeNull();
+    });
+  });
+
+  describe("webhook pass-through (#23)", () => {
+    test("GET webhooks list forwards live, body verbatim incl. token", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const webhooks = [
+        { id: "wh-1", name: "cc-fleet", token: "SECRET-TOKEN-abc", channel_id: "ch-1" },
+      ];
+      const client = mockClient({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: webhooks,
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const req = new Request("http://localhost/api/v10/channels/ch-1/webhooks", {
+        method: "GET",
+      });
+
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{ id: string; token: string }>;
+      // The token MUST survive — disc-server reuses the webhook by reading it
+      expect(body[0].token).toBe("SECRET-TOKEN-abc");
+      expect(client.captured.channelId).toBe("ch-1");
+    });
+
+    test("POST create webhook forwards, 201 verbatim", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: true,
+        status: 201,
+        headers: new Headers(),
+        body: { id: "wh-2", token: "new-tok" },
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const req = new Request("http://localhost/api/v10/channels/ch-1/webhooks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "cc-fleet" }),
+      });
+
+      const res = await handler(req);
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string };
+      expect(body.id).toBe("wh-2");
+      expect(client.captured.channelId).toBe("ch-1");
+      expect(client.captured.body).toContain("cc-fleet");
+    });
+
+    test("POST execute webhook forwards with ?wait=true preserved, 200 verbatim", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const sent = { id: "msg-1", channel_id: "ch-1", content: "via webhook" };
+      const client = mockClient({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: sent,
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const req = new Request(
+        "http://localhost/api/v10/webhooks/wh-1/SECRET-TOKEN-abc?wait=true",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: "via webhook", username: "cacophonix" }),
+        },
+      );
+
+      const res = await handler(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { id: string };
+      expect(body.id).toBe("msg-1");
+      expect(client.captured.channelId).toBe("wh-1"); // webhookId recorded
+      expect(client.captured.search).toBe("?wait=true"); // query preserved
+      expect(client.captured.body).toContain("cacophonix");
+    });
+
+    test("execute webhook 204 returns empty body without throwing (#22)", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: true,
+        status: 204,
+        headers: new Headers({ "Retry-After": "1" }),
+        body: "",
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const req = new Request(
+        "http://localhost/api/v10/webhooks/wh-1/tok",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: "x" }),
+        },
+      );
+
+      const res = await handler(req);
+
+      expect(res.status).toBe(204);
+      expect(await res.text()).toBe("");
+      // rate-limit headers still forwarded on a null-body status
+      expect(res.headers.get("Retry-After")).toBe("1");
+    });
+
+    test("webhook routes return 503 when no Discord client is configured", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const handler = createHandler(cache, "guild-1", TEST_TTL); // no client
+      for (const req of [
+        new Request("http://localhost/api/v10/channels/ch-1/webhooks", { method: "GET" }),
+        new Request("http://localhost/api/v10/channels/ch-1/webhooks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+        }),
+        new Request("http://localhost/api/v10/webhooks/wh-1/tok", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+        }),
+      ]) {
+        const res = await handler(req);
+        expect(res.status).toBe(503);
+      }
     });
   });
 });

--- a/tests/poller.test.ts
+++ b/tests/poller.test.ts
@@ -30,6 +30,15 @@ function makeMockClient(
     async createThread() {
       return { ok: true, status: 201, headers: new Headers(), body: {} };
     },
+    async listWebhooks() {
+      return { ok: true, status: 200, headers: new Headers(), body: [] };
+    },
+    async createWebhook() {
+      return { ok: true, status: 201, headers: new Headers(), body: {} };
+    },
+    async executeWebhook() {
+      return { ok: true, status: 200, headers: new Headers(), body: {} };
+    },
   };
 }
 
@@ -87,6 +96,15 @@ describe("initialPoll", () => {
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
       },
+      async listWebhooks() {
+        return { ok: true, status: 200, headers: new Headers(), body: [] };
+      },
+      async createWebhook() {
+        return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async executeWebhook() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
+      },
     };
 
     const cache = createCache(60_000, 4 * 60 * 60 * 1000);
@@ -132,6 +150,15 @@ describe("initialPoll", () => {
       },
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async listWebhooks() {
+        return { ok: true, status: 200, headers: new Headers(), body: [] };
+      },
+      async createWebhook() {
+        return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async executeWebhook() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
       },
     };
 
@@ -275,6 +302,15 @@ describe("channel backoff in polling", () => {
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
       },
+      async listWebhooks() {
+        return { ok: true, status: 200, headers: new Headers(), body: [] };
+      },
+      async createWebhook() {
+        return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async executeWebhook() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
+      },
     };
 
     const cache = createCache(60_000, 4 * 60 * 60 * 1000);
@@ -330,6 +366,15 @@ describe("channel backoff in polling", () => {
       },
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async listWebhooks() {
+        return { ok: true, status: 200, headers: new Headers(), body: [] };
+      },
+      async createWebhook() {
+        return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async executeWebhook() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
       },
     };
 

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -275,4 +275,81 @@ describe("createChannel / createThread — creation POSTs proxied (#18)", () => 
     expect(result.ok).toBe(false);
     expect(result.status).toBe(403);
   });
+
+  test("listWebhooks GETs /channels/{id}/webhooks", async () => {
+    const { fetch, captured } = urlCapturingFetch(200);
+    const client = createDiscordClient("test-token", fetch);
+
+    const result = await client.listWebhooks("ch-1");
+
+    expect(captured.url).toContain("/channels/ch-1/webhooks");
+    expect(captured.method).toBe("GET");
+    expect(result.status).toBe(200);
+  });
+
+  test("createWebhook POSTs /channels/{id}/webhooks", async () => {
+    const { fetch, captured } = urlCapturingFetch(201);
+    const client = createDiscordClient("test-token", fetch);
+
+    await client.createWebhook("ch-1", JSON.stringify({ name: "cc-fleet" }), "application/json");
+
+    expect(captured.url).toContain("/channels/ch-1/webhooks");
+    expect(captured.method).toBe("POST");
+  });
+
+  test("executeWebhook POSTs /webhooks/{id}/{token} with query preserved", async () => {
+    const { fetch, captured } = urlCapturingFetch(200);
+    const client = createDiscordClient("test-token", fetch);
+
+    await client.executeWebhook(
+      "wh-1",
+      "SECRET-TOKEN",
+      "?wait=true",
+      JSON.stringify({ content: "hi" }),
+      "application/json",
+    );
+
+    expect(captured.url).toContain("/webhooks/wh-1/SECRET-TOKEN?wait=true");
+    expect(captured.method).toBe("POST");
+  });
+
+  test("429 on executeWebhook does NOT log the webhook token (redacted)", async () => {
+    let calls = 0;
+    const rateLimitedThen200: FetchFn = async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response("{}", {
+          status: 429,
+          headers: { "Retry-After": "0" },
+        });
+      }
+      return new Response(JSON.stringify({ id: "msg-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      const client = createDiscordClient("test-token", rateLimitedThen200);
+      await client.executeWebhook(
+        "wh-1",
+        "SUPER-SECRET-TOKEN",
+        "?wait=true",
+        JSON.stringify({ content: "hi" }),
+        "application/json",
+      );
+    } finally {
+      console.warn = origWarn;
+    }
+
+    const joined = warnings.join("\n");
+    expect(joined).toContain("429 rate limited"); // the retry did log
+    expect(joined).not.toContain("SUPER-SECRET-TOKEN"); // but not the token
+    expect(joined).toContain("/webhooks/wh-1/***"); // it was masked
+  });
 });


### PR DESCRIPTION
## Summary

scream-hole never proxied Discord's webhook endpoints (zero `webhook` refs in source), so disc-server's per-agent webhook identity (#58) broke `disc_send` for new agents — the `GET /channels/{id}/webhooks` call routed through scream-hole and hit the catch-all `404 {"error":"not found"}`. This is the sibling of #18 (creation-POST proxying). Mitigation was already in place (global `webhook_identity` off → fallback to plain message-send); this restores custom name/avatar identities fleet-wide. Diagnosed + contract-reviewed by polyjuice (disc-server / #58 consumer).

## Changes

- **`discord.ts`** — extract `parseForward(res)` (shared by `forwardPost` + new `forwardGet`); add `listWebhooks` (live GET, body verbatim incl. `token`), `createWebhook` (POST), `executeWebhook(webhookId, token, search, …)` (top-level `/webhooks/{id}/{token}{search}`, query preserved). Redact the webhook token from the 429 retry log via `redactPathForLog` (the path carries a reusable credential).
- **`index.ts`** — add `GET`/`POST /api/v10/channels/{id}/webhooks` and top-level `POST /api/v10/webhooks/{id}/{token}` (query passed through via `url.search`). Fold in **#22**: `writeResponse` emits a null body for `NULL_BODY_STATUSES` (101/204/205/304) — a 204 from webhook-execute no longer throws — while still forwarding rate-limit headers.
- **Version** → `1.2.0` (minor; new feature; tag is authoritative).
- **Tests** — list-token-survives-verbatim, create 201, execute `?wait=true` preserved, 204 no-throw, 503 guards on all 3 routes, client-path correctness, and a regression test proving the token is redacted from 429 logs. All `DiscordClient` mocks updated.

## Linked Issues

Closes #23
Closes #22
Fixes the scream-hole side of Wave-Engineering/mcp-server-discord#58.

## Test Plan

- `./scripts/ci/validate.sh` → lint + shellcheck + `bun test`: **98 pass / 0 fail** (+9 new).
- Opus code review (precheck): found 1 important — webhook token leaked into the 429 retry log — **fixed** (`redactPathForLog` + regression test); focused re-review came back clean. Verified token round-trips verbatim through the list, route matchers don't shadow, no SSRF, guards sound.
- trivy: 0 HIGH/CRITICAL.

## Release

After merge: tag `v1.2.0` → `release.yml` builds + pushes `:1.2.0` + `:latest`. Release ≠ deploy — the swarm update is mother's separate gated step. @polyjuice owns contract verification on the execute `?wait=true`/token handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)