### PR TITLE
fix(proxy): route single-message GET; make proxy errors identifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,89 @@ DISCORD_BOT_TOKEN=your-token DISCORD_GUILD_ID=your-guild-id bun run start
 | GET | `/health` | Health check — status, uptime, version, cache stats |
 | GET | `/api/v10/guilds/{id}/channels` | Cached channel list |
 | GET | `/api/v10/channels/{id}/messages?after=SNOWFLAKE` | Cached messages (`after` required) |
+| GET | `/api/v10/channels/{id}/messages/{messageId}` | Single message — **live**, never cached (see below) |
 | POST | `/api/v10/channels/{id}/messages` | Write pass-through — forwards to Discord |
 
 The messages endpoint **fails open**: a quiet, idle, or not-yet-cached channel
 returns `200 []` (never 404), so consumers treat it as "nothing new" instead of
 falling back to Discord directly and storming its rate limit. Any `after` value
 is accepted, including `after=0` ("everything cached").
+
+Single-message fetch is deliberately **not** cache-backed. Callers use it to tell
+a deleted message from a transient failure, and a cache cannot represent a
+deletion it has not yet polled — so a cached hit would report a message deleted
+upstream as still present, inverting exactly the distinction the caller is
+making. It forwards live to Discord and returns Discord's status and body
+verbatim, including a genuine `404 {"message":"Unknown Message","code":10008}`.
+
+### Unrouted paths return 501, not 404
+
+A path this proxy does not serve returns:
+
+```json
+501 { "error": "no route for this path", "proxy": "scream-hole" }
+```
+
+**Do not use 404 to mean "the proxy has no such route."** Because scream-hole
+fronts Discord's API surface, a 404 from the proxy is indistinguishable from
+Discord's own `{"message":"Unknown Message","code":10008}`, and consumers read
+that as *the resource was deleted*. That ambiguity silently dropped forwarded
+messages for days — a missing route and a deleted message returned
+byte-comparable answers.
+
+### Who answered? Every proxy-originated error carries `proxy`
+
+The rule is broader than the catch-all. **Every error this proxy constructs
+itself** — 400s on bad parameters, the 503s when no Discord client is
+configured, the uncached-guild 404, the lease 400/405s, the 501 catch-all —
+carries `proxy: "scream-hole"`. A response **forwarded from Discord** never
+does; those pass through byte-for-byte.
+
+The general invariant, covering successes too:
+
+> **Every response scream-hole constructs on the Discord-impersonating surface
+> carries a positive origin marker** — `proxy` in the body for errors, `X-Cache`
+> in the headers for cache-backed reads. **Responses forwarded from Discord carry
+> neither.**
+
+The header half is not redundant: a cache read returns a bare Discord-shaped
+JSON array, which has nowhere to put a key, so body-stamping cannot cover the
+success side at all.
+
+| Response carries | Answered by | Meaning |
+|---|---|---|
+| `proxy: "scream-hole"` in body | this proxy | says nothing about the origin resource |
+| `X-Cache` header | this proxy, from cache | our view, possibly stale |
+| numeric `code` in body | Discord | authoritative about the resource |
+| neither marker | something else in the path | treat as transient, never as deletion |
+
+**Failures distinguish whose fault they were**, which matters because the two
+call for opposite responses:
+
+| Status | Means | Retry? |
+|---|---|---|
+| `502 {"error": "upstream Discord request failed", "proxy": …}` | we tried to reach Discord and could not | **yes** — transient by nature |
+| `500 {"error": "proxy failed to handle this request", "proxy": …}` | a fault inside this proxy; Discord may never have been contacted | **no** — retrying a deterministic bug just hides it |
+
+The 502 is raised only around the call that actually contacts Discord, never
+around surrounding logic. A proxy that blames the origin for its own faults is
+the same mislabeling this whole contract exists to prevent, just pointed the
+other way.
+
+**Scope of the markers.** `/health` and `/lease/*` **successes** are unmarked:
+Discord serves neither path, so provenance is never in question and stamping
+them would dilute what the marker means. Their **errors** are marked like every
+other error — the exemption covers successful responses only, and an error is
+where the ambiguity would actually cost something.
+
+Identify a proxy answer by the **presence of `proxy`**, never by the absence of
+Discord's `code`. Absence-based checks flip silently the first time either body
+grows a field, and stay wrong without failing any test.
+
+This is enforced in code rather than by convention: proxy-originated errors are
+built by a single `proxyError()` helper that stamps the key, so a route added
+later cannot forget to opt in. That is deliberate — the original outage happened
+because one unrouted path produced a body indistinguishable from Discord's.
 
 ## Development
 

--- a/discord.ts
+++ b/discord.ts
@@ -65,6 +65,17 @@ export interface DiscordClient {
     body: BodyInit,
     contentType: string,
   ): Promise<SendMessageResponse>;
+  /**
+   * Forward a live GET to `/channels/{channelId}/messages/{messageId}`.
+   *
+   * Deliberately NOT cache-backed. Callers use this to distinguish a deleted
+   * message (Discord 404) from a transient failure, so a cached hit for a
+   * message deleted upstream would invert that discrimination.
+   */
+  fetchMessage(
+    channelId: string,
+    messageId: string,
+  ): Promise<SendMessageResponse>;
   /** Forward a live GET to `/channels/{channelId}/webhooks` (body verbatim, incl. tokens). */
   listWebhooks(channelId: string): Promise<SendMessageResponse>;
   /** Forward a create-webhook POST to `/channels/{channelId}/webhooks`. */
@@ -240,6 +251,13 @@ export function createDiscordClient(
       contentType: string,
     ): Promise<SendMessageResponse> {
       return forwardPost(`/channels/${channelId}/threads`, body, contentType);
+    },
+
+    fetchMessage(
+      channelId: string,
+      messageId: string,
+    ): Promise<SendMessageResponse> {
+      return forwardGet(`/channels/${channelId}/messages/${messageId}`);
     },
 
     listWebhooks(channelId: string): Promise<SendMessageResponse> {

--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,24 @@ function writeResponse(result: SendMessageResponse): Response {
 }
 
 /**
+ * Build an error Response that ORIGINATED here rather than at Discord.
+ *
+ * Every proxy-originated error carries `proxy: "scream-hole"`; a response
+ * forwarded from Discord (see {@link writeResponse}) never does. That gives
+ * consumers a single, positive test for "who answered me" — check for the
+ * presence of `proxy`, never for the absence of Discord's `code`.
+ *
+ * Why this is a helper and not a convention: the #25 outage happened because a
+ * proxy-originated 404 was byte-comparable to Discord's own, and consumers read
+ * it as "the resource was deleted". Any error we construct is capable of that
+ * confusion, so stamping it must be structural — a future route that forgets to
+ * opt in is exactly how this class comes back.
+ */
+function proxyError(error: string, status: number): Response {
+  return Response.json({ error, proxy: "scream-hole" }, { status });
+}
+
+/**
  * Create the request handler with access to cache and config.
  * When a DiscordClient is provided, write pass-through (POST) routes are enabled.
  */
@@ -68,7 +86,111 @@ function createHandler(
   client?: DiscordClient,
 ) {
   const ttl = cacheTtlMs ?? Infinity;
+
+  /**
+   * Outermost guard: any throw that escapes the router would otherwise become
+   * Bun.serve's own bare 500 — no `proxy` marker, and so indistinguishable from
+   * Discord's `{"message":"500: Internal Server Error","code":0}`.
+   *
+   * The status here is 500 and the wording is deliberately NEUTRAL: at this
+   * depth we know only that WE failed, never why. An earlier version of this
+   * guard returned `502 "upstream Discord request failed"` for everything it
+   * caught, which was a lie on any route that never contacted Discord — a cache
+   * throw or a malformed body read got reported as an upstream fault. Since the
+   * README tells consumers to treat that as transient, a deterministic internal
+   * bug would have been retried forever instead of surfacing.
+   *
+   * That is worth spelling out because it is the #25 defect reproduced inside
+   * its own fix: mislabeling one party's failure as another's. Upstream failures
+   * are attributed narrowly, at the call that actually contacts Discord — see
+   * {@link forwardUpstream}. This guard only catches what that one misses.
+   */
   return async function handleRequest(req: Request): Promise<Response> {
+    // Built BEFORE the try, and nothing in the catch below may throw. A
+    // last-resort net that can itself tear is not a net: if `route` failed
+    // *because* `new URL(req.url)` threw, doing the same parse inside the catch
+    // would re-throw and escape as the unmarked bare 500 this guard exists to
+    // prevent. Same reason `String(err)` is avoided — it throws on a
+    // null-prototype value.
+    let label: string;
+    try {
+      label = `${req.method} ${new URL(req.url).pathname}`;
+    } catch {
+      // A literal, NOT `req.method` — that would re-run an expression from the
+      // try body that may be exactly what just failed, inside the block whose
+      // whole purpose is that it cannot fail. Unreachable for a spec-conformant
+      // Request, but the pattern is the one this file forbids elsewhere.
+      label = "<unknown request>";
+    }
+
+    try {
+      return await route(req);
+    } catch (err) {
+      // Logging is best-effort and is isolated so it can NEVER prevent the
+      // response. `err` is arbitrary — reading `.stack` or `.message` runs
+      // attacker/library-controlled getters, and interpolating the result runs a
+      // `toString`. Any of those can throw, and a throw here escapes as the
+      // unmarked bare 500 this guard exists to prevent.
+      //
+      // This is not theoretical: an earlier version did the read and the
+      // interpolation directly in this block, and an Error with an own throwing
+      // `stack` getter tore straight through it. Verified by test — see
+      // "the last-resort guard cannot be torn" in tests/index.test.ts.
+      try {
+        const detail =
+          err instanceof Error ? (err.stack ?? err.message) : "non-Error thrown value";
+        console.error(`[proxy] internal error handling ${label}: ${String(detail)}`);
+      } catch {
+        // Deliberately empty — a failure to DESCRIBE the failure must not
+        // escalate into a failure to ANSWER. Nothing is retried here on purpose:
+        // a fallback log inside this catch could throw for the same reason the
+        // first one did, which is the same mistake one level down.
+      }
+      return proxyError("proxy failed to handle this request", 500);
+    }
+  };
+
+  /**
+   * Run the one call that actually contacts Discord, converting a transport-level
+   * rejection (DNS failure, connection reset, TLS error) into an attributable 502.
+   *
+   * Scoped deliberately tight — around the upstream call and nothing else. 502
+   * asserts "we tried to reach the origin and could not", and that claim is only
+   * true here. Widening this to cover surrounding logic would make the proxy
+   * blame Discord for its own faults, which is the mislabeling this whole issue
+   * is about. Anything outside this call is an internal fault and gets the
+   * neutral 500 from the outer guard instead.
+   */
+  async function forwardUpstream(
+    fn: () => Promise<SendMessageResponse>,
+    onResult?: (result: SendMessageResponse) => void,
+  ): Promise<Response> {
+    let result: SendMessageResponse;
+    try {
+      result = await fn();
+    } catch (err) {
+      // Isolated for the same reason as the outer guard, and with a sharper
+      // consequence: a throw from this logging does not produce a bare 500 (the
+      // outer guard catches it) but it DOES lose the 502, silently downgrading
+      // "Discord was unreachable" to "we broke". That is the attribution this
+      // function exists to provide, discarded while describing the failure.
+      try {
+        const detail =
+          err instanceof Error ? (err.message ?? "") : "non-Error thrown value";
+        console.error(`[proxy] upstream Discord request failed: ${String(detail)}`);
+      } catch {
+        // Empty on purpose — see the outer guard. Describing a failure must
+        // never cost us the ability to attribute it.
+      }
+      return proxyError("upstream Discord request failed", 502);
+    }
+    // Outside the try on purpose: a throw from here is OUR bug, not Discord's,
+    // and must not be reported as an upstream failure.
+    onResult?.(result);
+    return writeResponse(result);
+  }
+
+  async function route(req: Request): Promise<Response> {
     const url = new URL(req.url);
 
     // Forward a resource-creation POST to Discord verbatim (#18). Shared by the
@@ -79,15 +201,11 @@ function createHandler(
       fn: (body: BodyInit, contentType: string) => Promise<SendMessageResponse>,
     ): Promise<Response> {
       if (!client) {
-        return Response.json(
-          { error: "Write pass-through is not configured (no Discord client)" },
-          { status: 503 },
-        );
+        return proxyError("Write pass-through is not configured (no Discord client)", 503);
       }
       const contentType = req.headers.get("Content-Type") ?? "application/json";
       const rawBody = await req.arrayBuffer();
-      const result = await fn(rawBody, contentType);
-      return writeResponse(result);
+      return forwardUpstream(() => fn(rawBody, contentType));
     }
 
     // Health endpoint — includes cache stats
@@ -113,7 +231,7 @@ function createHandler(
       const action = leaseMatch[2];
       if (action === "status" && req.method === "GET") {
         const channel = url.searchParams.get("channel");
-        if (!channel) return Response.json({ error: "channel query param required" }, { status: 400 });
+        if (!channel) return proxyError("channel query param required", 400);
         return Response.json({ kind, channel, lease: status(kind, channel) });
       }
       if ((action === "claim" || action === "release") && req.method === "POST") {
@@ -123,7 +241,7 @@ function createHandler(
           ttl_ms?: number;
         };
         if (!body.channel || !body.holder) {
-          return Response.json({ error: "channel and holder are required" }, { status: 400 });
+          return proxyError("channel and holder are required", 400);
         }
         if (action === "claim") {
           const ttl =
@@ -132,7 +250,7 @@ function createHandler(
         }
         return Response.json({ kind, channel: body.channel, ...release(kind, body.channel, body.holder) });
       }
-      return Response.json({ error: "method not allowed" }, { status: 405 });
+      return proxyError("method not allowed", 405);
     }
 
     // GET /api/v10/guilds/{guildId}/channels
@@ -143,10 +261,7 @@ function createHandler(
       const reqGuildId = channelsMatch[1];
       const result = cache.getChannels(reqGuildId);
       if (!result) {
-        return Response.json(
-          { error: `No cached data for guild ${reqGuildId}` },
-          { status: 404 },
-        );
+        return proxyError(`No cached data for guild ${reqGuildId}`, 404);
       }
       const channelFresh = Date.now() - result.cachedAt <= ttl;
       return new Response(JSON.stringify(result.data), {
@@ -177,10 +292,10 @@ function createHandler(
       // `after` is REQUIRED and must be a valid snowflake (numeric string)
       const after = url.searchParams.get("after");
       if (!after || !/^\d+$/.test(after)) {
-        return Response.json(
-          { error: "`after` query parameter is required and must be a valid snowflake ID (numeric string)" },
-          { status: 400 },
-        );
+        return proxyError(
+            "`after` query parameter is required and must be a valid snowflake ID (numeric string)",
+            400,
+          );
       }
 
       const limitParam = url.searchParams.get("limit");
@@ -188,10 +303,7 @@ function createHandler(
       if (limitParam !== null) {
         const parsed = Number(limitParam);
         if (!Number.isInteger(parsed) || parsed <= 0) {
-          return Response.json(
-            { error: "`limit` must be a positive integer" },
-            { status: 400 },
-          );
+          return proxyError("`limit` must be a positive integer", 400);
         }
         limit = parsed;
       }
@@ -226,10 +338,7 @@ function createHandler(
     // POST /api/v10/channels/{channelId}/messages — write pass-through
     if (req.method === "POST" && messagesMatch) {
       if (!client) {
-        return Response.json(
-          { error: "Write pass-through is not configured (no Discord client)" },
-          { status: 503 },
-        );
+        return proxyError("Write pass-through is not configured (no Discord client)", 503);
       }
 
       const channelId = messagesMatch[1];
@@ -238,33 +347,71 @@ function createHandler(
       // Read the raw body to forward transparently (supports JSON and multipart)
       const rawBody = await req.arrayBuffer();
 
-      const result = await client.sendMessage(
-        channelId,
-        rawBody,
-        contentType,
-      );
-
-      // On success, inject the returned message into the cache
-      if (result.ok) {
-        const msg = result.body as DiscordMessage;
-        if (msg && typeof msg.id === "string" && /^\d+$/.test(msg.id)) {
-          try {
-            cache.setMessages(channelId, [msg]);
-          } catch {
-            // Cache write failure should not break the response
+      // Returns Discord's response verbatim (status + body + rate-limit headers);
+      // a transport-level rejection becomes an attributable 502 rather than a
+      // 500 blamed on us or a bare 500 blamed on nobody.
+      return forwardUpstream(
+        () => client.sendMessage(channelId, rawBody, contentType),
+        (result) => {
+          // On success, inject the returned message into the cache
+          if (result.ok) {
+            const msg = result.body as DiscordMessage;
+            if (msg && typeof msg.id === "string" && /^\d+$/.test(msg.id)) {
+              try {
+                cache.setMessages(channelId, [msg]);
+              } catch {
+                // Cache write failure should not break the response
+              }
+            }
           }
-        }
-      }
+        },
+      );
+    }
 
-      // Return Discord's response verbatim (status + body + rate-limit headers)
-      return writeResponse(result);
+    // GET /api/v10/channels/{channelId}/messages/{messageId} — single-message fetch (#25)
+    //
+    // Needs its own route because the LIST regex above is `$`-anchored: this form
+    // has an extra path segment, so before #25 it fell through to the catch-all and
+    // returned the proxy's own 404. Consumers read that 404 as "the message was
+    // deleted" (watcher #41 `fetchMessageById` maps any 404 to `gone`, and `gone` is
+    // dropped rather than retried), so every forwarded message was silently lost.
+    //
+    // Live, non-cached forward — and that is load-bearing, not incidental. Serving
+    // this from cache would return a stale hit for a message deleted upstream,
+    // inverting the exact deleted-vs-transient discrimination the caller is making:
+    // a silent false positive, strictly worse than the 404 it replaces. The cost is
+    // one live Discord call per lookup, on the low-volume forward path only.
+    const messageByIdMatch = url.pathname.match(
+      /^\/api\/v10\/channels\/([^/]+)\/messages\/([^/]+)$/,
+    );
+    if (req.method === "GET" && messageByIdMatch) {
+      if (!client) {
+        return proxyError("Single-message fetch is not configured (no Discord client)", 503);
+      }
+      const [, channelId, messageId] = messageByIdMatch;
+      // Snowflake-validate before forwarding. The reason is the same failure this
+      // whole route exists to fix: an unvalidated id would be forwarded upstream
+      // and come back as Discord's own 404, which callers read as "deleted" and
+      // drop silently — so a typo'd id would vanish a message exactly the way an
+      // unrouted path used to. A 400 is read as an error and retried/surfaced.
+      // Secondarily, this route is uncached, so every request is a live Discord
+      // call; rejecting garbage here keeps malformed ids off our rate budget.
+      //
+      // Not a path-traversal guard: `..` and `%2e%2e` are already collapsed by
+      // `new URL(req.url)` above, so they can never reach this regex as a segment.
+      // Matches the snowflake checks the LIST route applies to `after` (:179) and
+      // the cache-injection path applies to `msg.id` (:250).
+      if (!/^\d+$/.test(messageId!)) {
+        return proxyError("`messageId` must be a valid snowflake ID (numeric string)", 400);
+      }
+      return forwardUpstream(() => client.fetchMessage(channelId!, messageId!));
     }
 
     // POST /api/v10/channels/{channelId}/threads — create-thread pass-through (#18, mcp#47)
     // Covers standalone thread creation only. The message-anchored form
     // POST /channels/{id}/messages/{id}/threads is NOT matched here — no
     // consumer creates threads from a message today; add a route if that
-    // changes (otherwise it would 404 through the proxy).
+    // changes (otherwise it falls through to the 501 catch-all).
     const threadsMatch = url.pathname.match(
       /^\/api\/v10\/channels\/([^/]+)\/threads$/,
     );
@@ -279,15 +426,12 @@ function createHandler(
     );
     if (req.method === "GET" && webhooksMatch) {
       if (!client) {
-        return Response.json(
-          { error: "Webhook pass-through is not configured (no Discord client)" },
-          { status: 503 },
-        );
+        return proxyError("Webhook pass-through is not configured (no Discord client)", 503);
       }
       // Live, non-cached forward: webhook tokens must not be cached/staled, and
       // the body (each webhook's `token`) passes through verbatim so consumers
       // reuse an existing webhook instead of exhausting Discord's per-channel cap.
-      return writeResponse(await client.listWebhooks(webhooksMatch[1]));
+      return forwardUpstream(() => client.listWebhooks(webhooksMatch[1]!));
     }
     if (req.method === "POST" && webhooksMatch) {
       const channelId = webhooksMatch[1];
@@ -307,8 +451,23 @@ function createHandler(
       );
     }
 
-    return Response.json({ error: "not found" }, { status: 404 });
-  };
+    // Unrouted path (#25). Deliberately NOT 404.
+    //
+    // This proxy impersonates Discord's API surface, so a 404 from here is
+    // indistinguishable from Discord's own `{"message":"Unknown Message",
+    // "code":10008}` — and consumers read that as "the resource was deleted".
+    // That misread is not hypothetical: it silently dropped every forwarded
+    // message for days, because a missing route and a deleted message gave the
+    // caller byte-comparable answers. A 404 asserts something about the origin
+    // resource that we never asked the origin. 501 says the true thing: this
+    // proxy does not serve this path.
+    //
+    // `proxy` identifies us POSITIVELY. Consumers should discriminate on its
+    // presence, not on the absence of Discord's `code` field — an absence-based
+    // check flips silently the day either body grows a field, and stays wrong
+    // without failing any test.
+    return proxyError("no route for this path", 501);
+  }
 }
 
 // Only start the server when run directly (not during tests importing this module)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -40,6 +40,73 @@ function makeChannel(id: string, name: string): DiscordChannel {
 const TEST_TTL = 60_000;
 const TEST_WINDOW = 4 * 60 * 60 * 1000; // 4 hours
 
+/**
+ * Helper: build a mock DiscordClient with a controllable response, capturing
+ * the id/body/content-type of the last write (send, create-channel, or
+ * create-thread).
+ */
+function mockClient(
+  sendResponse: SendMessageResponse,
+): DiscordClient & {
+  captured: {
+    channelId: string;
+    messageId: string;
+    body: string;
+    contentType: string;
+    search: string;
+  };
+} {
+  const captured = { channelId: "", messageId: "", body: "", contentType: "", search: "" };
+  const record = (id: string, body: BodyInit, contentType: string) => {
+    captured.channelId = id;
+    if (body instanceof ArrayBuffer) {
+      captured.body = new TextDecoder().decode(body);
+    } else if (typeof body === "string") {
+      captured.body = body;
+    }
+    captured.contentType = contentType;
+  };
+  return {
+    captured,
+    async fetchChannels() {
+      return [];
+    },
+    async fetchMessages() {
+      return [];
+    },
+    async sendMessage(channelId, body, contentType) {
+      record(channelId, body, contentType);
+      return sendResponse;
+    },
+    async createChannel(guildId, body, contentType) {
+      record(guildId, body, contentType);
+      return sendResponse;
+    },
+    async createThread(channelId, body, contentType) {
+      record(channelId, body, contentType);
+      return sendResponse;
+    },
+    async fetchMessage(channelId, messageId) {
+      captured.channelId = channelId;
+      captured.messageId = messageId;
+      return sendResponse;
+    },
+    async listWebhooks(channelId) {
+      captured.channelId = channelId;
+      return sendResponse;
+    },
+    async createWebhook(channelId, body, contentType) {
+      record(channelId, body, contentType);
+      return sendResponse;
+    },
+    async executeWebhook(webhookId, token, search, body, contentType) {
+      record(webhookId, body, contentType);
+      captured.search = search;
+      return sendResponse;
+    },
+  };
+}
+
 describe("GET /health", () => {
   test("returns 200 with status ok, uptime, version, and cache stats", async () => {
     const cache = createCache(TEST_TTL, TEST_WINDOW);
@@ -281,60 +348,6 @@ describe("GET /api/v10/channels/{channelId}/messages", () => {
 });
 
 describe("POST /api/v10/channels/{channelId}/messages", () => {
-  /**
-   * Helper: build a mock DiscordClient with a controllable response, capturing
-   * the id/body/content-type of the last write (send, create-channel, or
-   * create-thread).
-   */
-  function mockClient(
-    sendResponse: SendMessageResponse,
-  ): DiscordClient & { captured: { channelId: string; body: string; contentType: string; search: string } } {
-    const captured = { channelId: "", body: "", contentType: "", search: "" };
-    const record = (id: string, body: BodyInit, contentType: string) => {
-      captured.channelId = id;
-      if (body instanceof ArrayBuffer) {
-        captured.body = new TextDecoder().decode(body);
-      } else if (typeof body === "string") {
-        captured.body = body;
-      }
-      captured.contentType = contentType;
-    };
-    return {
-      captured,
-      async fetchChannels() {
-        return [];
-      },
-      async fetchMessages() {
-        return [];
-      },
-      async sendMessage(channelId, body, contentType) {
-        record(channelId, body, contentType);
-        return sendResponse;
-      },
-      async createChannel(guildId, body, contentType) {
-        record(guildId, body, contentType);
-        return sendResponse;
-      },
-      async createThread(channelId, body, contentType) {
-        record(channelId, body, contentType);
-        return sendResponse;
-      },
-      async listWebhooks(channelId) {
-        captured.channelId = channelId;
-        return sendResponse;
-      },
-      async createWebhook(channelId, body, contentType) {
-        record(channelId, body, contentType);
-        return sendResponse;
-      },
-      async executeWebhook(webhookId, token, search, body, contentType) {
-        record(webhookId, body, contentType);
-        captured.search = search;
-        return sendResponse;
-      },
-    };
-  }
-
   test("forwards POST body to Discord via client and returns response", async () => {
     const cache = createCache(TEST_TTL, TEST_WINDOW);
     const sentMsg: DiscordMessage = {
@@ -734,31 +747,68 @@ describe("POST /api/v10/channels/{channelId}/messages", () => {
       expect(client.captured.body).toContain("cacophonix");
     });
 
-    test("execute webhook 204 returns empty body without throwing (#22)", async () => {
+    // Parameterised over EVERY status in NULL_BODY_STATUSES, not just 204.
+    // The constant's docblock claims all four throw if given a body; only 204
+    // had a test behind it, so removing 101/205/304 from the set changed
+    // nothing observable. The claim covers four statuses, so the check does too.
+    test.each([101, 204, 205, 304])(
+      "execute webhook %i returns empty body without throwing (#22)",
+      async (status) => {
+        const cache = createCache(TEST_TTL, TEST_WINDOW);
+        const client = mockClient({
+          ok: true,
+          status,
+          headers: new Headers({ "Retry-After": "1" }),
+          body: "",
+        });
+
+        const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+        const req = new Request(
+          "http://localhost/api/v10/webhooks/wh-1/tok",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ content: "x" }),
+          },
+        );
+
+        const res = await handler(req);
+
+        expect(res.status).toBe(status);
+        expect(await res.text()).toBe("");
+        // rate-limit headers still forwarded on a null-body status
+        expect(res.headers.get("Retry-After")).toBe("1");
+      },
+    );
+
+    // Pins "webhook tokens must not be cached/staled" (index.ts, webhook-list
+    // route). True by construction today — nothing on that path touches the
+    // cache — but nothing HELD it there: adding a working cache left the suite
+    // green. A stale webhook token is a live credential that has been revoked
+    // upstream, so this is a correctness claim, not a freshness preference.
+    test("webhook list forwards live on every call — never cached", async () => {
       const cache = createCache(TEST_TTL, TEST_WINDOW);
       const client = mockClient({
         ok: true,
-        status: 204,
-        headers: new Headers({ "Retry-After": "1" }),
-        body: "",
+        status: 200,
+        headers: new Headers(),
+        body: [{ id: "wh-1", token: "secret-token" }],
       });
+      let calls = 0;
+      client.listWebhooks = async () => {
+        calls += 1;
+        return { ok: true, status: 200, headers: new Headers(), body: [{ id: "wh-1" }] };
+      };
 
       const handler = createHandler(cache, "guild-1", TEST_TTL, client);
-      const req = new Request(
-        "http://localhost/api/v10/webhooks/wh-1/tok",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content: "x" }),
-        },
-      );
+      const req = () =>
+        new Request("http://localhost/api/v10/channels/ch-1/webhooks");
 
-      const res = await handler(req);
+      await handler(req());
+      await handler(req());
 
-      expect(res.status).toBe(204);
-      expect(await res.text()).toBe("");
-      // rate-limit headers still forwarded on a null-body status
-      expect(res.headers.get("Retry-After")).toBe("1");
+      // Two requests ⇒ two upstream calls. A cache would make this 1.
+      expect(calls).toBe(2);
     });
 
     test("webhook routes return 503 when no Discord client is configured", async () => {
@@ -782,18 +832,986 @@ describe("POST /api/v10/channels/{channelId}/messages", () => {
       }
     });
   });
+
+  describe("single-message fetch (#25)", () => {
+    test("forwards GET /messages/{messageId} to Discord and returns it verbatim", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const msg = makeMessage("111222333444555666", "ch-1", "the forwarded one");
+      const client = mockClient({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: msg,
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(
+        new Request("http://localhost/api/v10/channels/ch-1/messages/111222333444555666"),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(msg);
+      expect(client.captured.channelId).toBe("ch-1");
+      expect(client.captured.messageId).toBe("111222333444555666");
+    });
+
+    // The whole point of the route: a deleted message must surface Discord's own
+    // 404 body, not the proxy catch-all's. Callers key on that distinction to tell
+    // "deleted" from "the proxy does not route this".
+    test("passes through Discord's real 404 for a deleted message", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        body: { message: "Unknown Message", code: 10008 },
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(
+        new Request("http://localhost/api/v10/channels/ch-1/messages/222333444555666777"),
+      );
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ message: "Unknown Message", code: 10008 });
+    });
+
+    // Load-bearing: serving this from cache would report a message deleted
+    // upstream as still present, inverting the caller's deleted-vs-transient
+    // discrimination. Seed the cache with the exact id, then assert we still
+    // hit Discord and return Discord's answer rather than the cached copy.
+    test("never serves from cache — forwards live even when the id is cached", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const cachedId = timestampToSnowflake(Date.now() - 60_000);
+      cache.setMessages("ch-1", [makeMessage(cachedId, "ch-1", "stale copy")]);
+
+      const client = mockClient({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+        body: { message: "Unknown Message", code: 10008 },
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(
+        new Request(`http://localhost/api/v10/channels/ch-1/messages/${cachedId}`),
+      );
+
+      expect(client.captured.messageId).toBe(cachedId);
+      expect(res.status).toBe(404);
+      expect(res.headers.get("X-Cache")).toBeNull();
+    });
+
+    test("forwards allowlisted rate-limit headers", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: false,
+        status: 429,
+        headers: new Headers({
+          "Retry-After": "2",
+          "X-RateLimit-Bucket": "abc",
+          "Set-Cookie": "leak=nope",
+        }),
+        body: { message: "You are being rate limited.", retry_after: 2 },
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(
+        new Request("http://localhost/api/v10/channels/ch-1/messages/333444555666777888"),
+      );
+
+      expect(res.status).toBe(429);
+      expect(res.headers.get("Retry-After")).toBe("2");
+      expect(res.headers.get("X-RateLimit-Bucket")).toBe("abc");
+      expect(res.headers.get("Set-Cookie")).toBeNull();
+    });
+
+    test("returns 503 when no Discord client is configured", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const handler = createHandler(cache, "guild-1", TEST_TTL); // no client
+      const res = await handler(
+        new Request("http://localhost/api/v10/channels/ch-1/messages/333444555666777888"),
+      );
+
+      expect(res.status).toBe(503);
+    });
+
+    // A malformed id must NOT be forwarded: Discord would answer its own 404,
+    // which callers read as "deleted" and drop silently — the same disappearance
+    // this route exists to stop, just triggered by a typo instead of a route gap.
+    // 400 is read as an error, so the message survives.
+    test("rejects a non-snowflake messageId instead of forwarding it", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: {},
+      });
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+
+      for (const bad of ["not-a-snowflake", "12a", "%2F..", "-1"]) {
+        const res = await handler(
+          new Request(`http://localhost/api/v10/channels/ch-1/messages/${bad}`),
+        );
+        expect(res.status).toBe(400);
+      }
+
+      // Never reached the client — the guard runs before any upstream call.
+      expect(client.captured.messageId).toBe("");
+    });
+
+    // Documents why the guard is NOT a path-traversal defense: `new URL()` collapses
+    // dot segments before the router sees them, so `..` can never arrive AS a
+    // messageId. Pinned so nobody later "hardens" the regex against a threat that
+    // the URL parser has already made unreachable.
+    test("dot segments are collapsed by URL parsing before routing", async () => {
+      for (const seg of ["..", "%2e%2e", "%2E%2E"]) {
+        const url = new URL(
+          `http://localhost/api/v10/channels/ch-1/messages/${seg}`,
+        );
+        expect(url.pathname).toBe("/api/v10/channels/ch-1/");
+      }
+    });
+
+    // Regression guard for the original defect: the LIST route's `$` anchor made
+    // this path fall through to the catch-all.
+    //
+    // Asserted POSITIVELY — on the routed response we expect — not negatively on
+    // the catch-all body we don't. An earlier version of this test checked
+    // `not.toMatchObject({error: "not found"})`, and changing the catch-all body
+    // silently made it unfalsifiable: it passed whether the route worked or fell
+    // through. A regression guard phrased as "not the old wrong answer" dies the
+    // moment the wrong answer is reworded, and dies green.
+    test("does not fall through to the catch-all", async () => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: makeMessage("444555666777888999", "ch-1", "routed"),
+      });
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(
+        new Request("http://localhost/api/v10/channels/ch-1/messages/444555666777888999"),
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.id).toBe("444555666777888999");
+      expect(body.content).toBe("routed");
+      // No `proxy` key ⇒ this came from Discord, not from our own error path.
+      expect(body.proxy).toBeUndefined();
+    });
+  });
 });
 
 describe("unknown routes", () => {
-  test("returns 404 for unknown path", async () => {
+  // #25: an unrouted path must NOT answer 404. This proxy fronts Discord, so a
+  // 404 from here is byte-comparable to Discord's own "Unknown Message" and gets
+  // read as "the resource was deleted" — the exact confusion that silently
+  // dropped forwarded messages. 501 is the honest answer: we never asked the
+  // origin, we just don't serve this path.
+  test("returns 501 (not 404) for an unknown path", async () => {
     const cache = createCache(TEST_TTL, TEST_WINDOW);
     const handler = createHandler(cache, "guild-1");
     const req = new Request("http://localhost/unknown", { method: "GET" });
     const res = await handler(req);
 
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(501);
+    expect(res.status).not.toBe(404);
 
     const body = await res.json();
-    expect(body.error).toBe("not found");
+    expect(body.error).toBe("no route for this path");
+  });
+
+  // Consumers must be able to identify a proxy miss by a key that is PRESENT,
+  // not by the absence of Discord's `code`. Absence-based discrimination flips
+  // silently if either body shape ever grows a field; this pins the positive form.
+  test("self-identifies as the proxy rather than relying on absence", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const handler = createHandler(cache, "guild-1");
+    const res = await handler(new Request("http://localhost/unknown"));
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.proxy).toBe("scream-hole");
+    // Must never look like a Discord error body.
+    expect(body.code).toBeUndefined();
+    expect(body.message).toBeUndefined();
+  });
+
+  // An unrouted path under a *routed* prefix is the shape that caused #25 — the
+  // `$`-anchored messages regex let the extra segment fall through here.
+  test("an unrouted subpath under a routed prefix also returns 501", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const handler = createHandler(cache, "guild-1");
+    const res = await handler(
+      new Request("http://localhost/api/v10/channels/ch-1/messages/123/reactions"),
+    );
+
+    expect(res.status).toBe(501);
+  });
+
+  // Unrouted *verbs* on a routed path fall here too. Message edit/delete are the
+  // most likely routes to be added next, so pin where they land today.
+  test.each(["DELETE", "PATCH", "PUT"])(
+    "%s on a routed path returns 501",
+    async (method) => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const handler = createHandler(cache, "guild-1");
+      const res = await handler(
+        new Request(
+          "http://localhost/api/v10/channels/ch-1/messages/111222333444555666",
+          { method },
+        ),
+      );
+
+      expect(res.status).toBe(501);
+    },
+  );
+});
+
+// The contract the README documents: consumers identify a proxy-origin answer by
+// the PRESENCE of `proxy`. That only works if it holds for every error we
+// construct — one route omitting it recreates #25 on that route, which is what
+// happened to the uncached-guild 404 when the rule was first written down.
+//
+// The rows below cover every route-level error site. That claim is not left to
+// prose: `proxyError call sites are all covered` derives the count from the
+// source, so adding a site without adding a row fails the suite. An earlier
+// version of this header asserted exhaustiveness in a comment while a site was
+// in fact uncovered — a false exhaustiveness claim is worse than an acknowledged
+// gap, because the next reader trusts it instead of checking.
+describe("proxy-origin error contract (#25)", () => {
+  test("proxyError call sites are all covered by a row or an attribution test", async () => {
+    const src = await Bun.file(
+      new URL("../index.ts", import.meta.url).pathname,
+    ).text();
+    // Call sites only: `return proxyError(` at a statement position. A bare
+    // /\bproxyError\(/ also matches occurrences inside comments and string
+    // literals — there are none today, but a future doc comment mentioning
+    // `proxyError(...)` would inflate the count and red the suite with a
+    // misleading failure. Anchoring on `return ` also excludes the definition,
+    // so no off-by-one adjustment is needed.
+    const sites = [...src.matchAll(/return proxyError\(/g)].length;
+
+    // 2 handler-level sites (the neutral 500 and the upstream 502) are covered by
+    // the "upstream failure is attributable" describe, not by a table row.
+    const HANDLER_LEVEL = 2;
+    // Rows that share a site with another row: the `after` 400 site serves both
+    // the missing-`after` and malformed-`after` cases. (Deliberately not cited by
+    // line number — those go stale silently, and this comment is what a reader
+    // consults to decide whether the constant is still right.)
+    const DUPLICATE_COVERAGE_ROWS = 1;
+
+    // DERIVED from the source count rather than pinned independently. An earlier
+    // version asserted two literals against two separate sources with nothing
+    // tying them to each other, so adding a site AND bumping the constant passed
+    // green. Deriving the row count removes that particular hole.
+    expect(cases.length).toBe(sites - HANDLER_LEVEL + DUPLICATE_COVERAGE_ROWS);
+
+    // LIMITS OF THIS CHECK — stated here because a reader deciding whether to
+    // trust it is standing here, and because an earlier version of this comment
+    // overstated the guarantee, which is the failure this whole describe exists
+    // to prevent:
+    //   - It is a tripwire, NOT a proof. It counts sites and rows; it CANNOT
+    //     verify that a row exercises the site it names. A row pointed at the
+    //     wrong site still counts — a real bug this suite has already had once,
+    //     which this check would not have caught.
+    //   - TWO CONSTANTS REMAIN HAND-MAINTAINED. A new site can still be absorbed
+    //     by bumping `HANDLER_LEVEL` or `DUPLICATE_COVERAGE_ROWS` instead of
+    //     adding a row. The check makes that a deliberate act, not an invisible
+    //     one — it does not make it impossible. Nothing anchors
+    //     `DUPLICATE_COVERAGE_ROWS` to the actual number of shared sites.
+    //   - Per-site coverage rests on mutation runs done BY HAND (bypassing the
+    //     helper at one site and confirming exactly the row naming it fails).
+    //     NOTHING IN THIS SUITE RERUNS THEM. If you change the table, redo them.
+  });
+
+  // Each case pins the STATUS it should produce, not just the marker. Without
+  // that, a case can reach a different site than intended and still pass: the
+  // `bad messageId` case originally ran with no client, so the `!client` 503
+  // guard fired before the snowflake check and it silently re-tested the
+  // no-client path. Asserting the status is what makes each row hit its own site.
+  //
+  // `withClient` is REQUIRED on every row, never optional — and that is not
+  // style. `test.each` passes an extra trailing argument beyond the row's own
+  // elements, so an optional 4th param silently receives it and reads truthy on
+  // every short row. That made all four no-client cases run WITH a client and
+  // stop testing the 503 they name. A required field makes tsc reject a row that
+  // omits it, which is how it was caught; arity-dependent binding is not.
+  const cases: Array<[string, Request, number, boolean]> = [
+    ["catch-all 501", new Request("http://localhost/unknown"), 501, false],
+    [
+      "uncached guild 404",
+      new Request("http://localhost/api/v10/guilds/no-such-guild/channels"),
+      404,
+      false,
+    ],
+    [
+      "missing `after` 400",
+      new Request("http://localhost/api/v10/channels/ch-1/messages"),
+      400,
+      false,
+    ],
+    [
+      "bad `after` 400",
+      new Request("http://localhost/api/v10/channels/ch-1/messages?after=abc"),
+      400,
+      false,
+    ],
+    [
+      "bad `limit` 400",
+      new Request("http://localhost/api/v10/channels/ch-1/messages?after=0&limit=abc"),
+      400,
+      false,
+    ],
+    [
+      "bad messageId 400",
+      new Request("http://localhost/api/v10/channels/ch-1/messages/not-a-snowflake"),
+      400,
+      true,
+    ],
+    ["lease missing channel 400", new Request("http://localhost/lease/mic/status"), 400, false],
+    [
+      "lease missing holder 400",
+      new Request("http://localhost/lease/mic/claim", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channel: "ch-1" }), // no `holder`
+      }),
+      400,
+      false,
+    ],
+    [
+      "lease bad method 405",
+      new Request("http://localhost/lease/mic/claim", { method: "DELETE" }),
+      405,
+      false,
+    ],
+    [
+      "single-message no client 503",
+      new Request("http://localhost/api/v10/channels/ch-1/messages/111222333444555666"),
+      503,
+      false,
+    ],
+    [
+      "webhook list no client 503",
+      new Request("http://localhost/api/v10/channels/ch-1/webhooks"),
+      503,
+      false,
+    ],
+    [
+      "create-channel no client 503",
+      new Request("http://localhost/api/v10/guilds/guild-1/channels", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+      503,
+      false,
+    ],
+    [
+      "POST messages no client 503",
+      new Request("http://localhost/api/v10/channels/ch-1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+      503,
+      false,
+    ],
+  ];
+
+  test.each(cases)(
+    "%s self-identifies as proxy-origin",
+    async (_name, req, expectedStatus, withClient) => {
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = withClient
+        ? mockClient({ ok: true, status: 200, headers: new Headers(), body: {} })
+        : undefined;
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(req);
+
+      // Pins that this row exercised the site it names, not a guard above it.
+      expect(res.status).toBe(expectedStatus);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.proxy).toBe("scream-hole");
+      // Must never be mistakable for a Discord error body.
+      expect(body.code).toBeUndefined();
+      expect(body.message).toBeUndefined();
+    },
+  );
+});
+
+// A rejected upstream fetch (DNS failure, connection reset, TLS error) must not
+// escape as Bun's bare 500 — that carries no marker and is indistinguishable
+// from Discord's own `{"message":"500: Internal Server Error","code":0}`, so a
+// consumer would read OUR network failure as Discord's answer. Same confusion
+// as #25, different costume.
+describe("upstream failure is attributable (#25)", () => {
+  test("a thrown upstream fetch becomes a marked 502, not a bare 500", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const client = mockClient({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: {},
+    });
+    client.fetchMessage = async () => {
+      throw new TypeError("fetch failed: ECONNRESET");
+    };
+
+    const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+    const res = await handler(
+      new Request("http://localhost/api/v10/channels/ch-1/messages/111222333444555666"),
+    );
+
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.proxy).toBe("scream-hole");
+    // Never mistakable for Discord's own 500 envelope.
+    expect(body.code).toBeUndefined();
+    expect(body.message).toBeUndefined();
+  });
+
+  // Pins the deliberate placement of `onResult` and `writeResponse` OUTSIDE
+  // forwardUpstream's try. That placement carries a comment asserting "a throw
+  // from here is OUR bug, not Discord's" — and nothing tested it: moving both
+  // back inside the try left the suite green.
+  //
+  // The path is reachable, not theoretical. `writeResponse` calls
+  // `JSON.stringify(result.body)`, which throws on a circular body or a throwing
+  // `toJSON`; `onResult` dereferences `result.body`. Either would be reported as
+  // an upstream failure — the exact mislabeling this file spends forty lines of
+  // comment repudiating, in the comment that repudiates it.
+  test("a throw while BUILDING the response is ours (500), never Discord's (502)", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    // Discord answered fine. We fail turning its answer into a Response.
+    const client = mockClient({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: {
+        toJSON() {
+          throw new Error("unserialisable body");
+        },
+      },
+    });
+
+    const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+    const res = await handler(
+      new Request("http://localhost/api/v10/channels/ch-1/messages/111222333444555666"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(res.status).not.toBe(502);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.proxy).toBe("scream-hole");
+    // Discord was reachable and answered — we must not blame it for our failure.
+    expect(String(body.error)).not.toContain("upstream");
+    expect(String(body.error)).not.toContain("Discord");
+  });
+
+  // The SECOND half of the same guarantee. The comment at forwardUpstream names
+  // two statements outside the try — `onResult?.(result)` AND `writeResponse(result)`
+  // — and the toJSON fixture above only reaches the second. Moving `onResult`
+  // alone inside the try left the suite green, so the claim was broader than the
+  // test.
+  //
+  // Reachable through the sole onResult caller, the message-send cache injection:
+  // it does `result.body as DiscordMessage` then reads `msg.id`. A throwing `id`
+  // getter is reported as 502 — blaming Discord for our own cache-injection fault
+  // — under the mutated arrangement.
+  test("a throw from the cache-injection hook is ours (500), never Discord's (502)", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const hostileBody: Record<string, unknown> = {};
+    Object.defineProperty(hostileBody, "id", {
+      get() {
+        throw new Error("id getter exploded");
+      },
+    });
+    // Self-verifying, same standard as the other hostile fixtures: prove the
+    // getter actually fires before relying on it.
+    expect(() => (hostileBody as { id?: unknown }).id).toThrow();
+
+    // ok:true so the injection branch is entered at all.
+    const client = mockClient({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: hostileBody,
+    });
+
+    const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+    const res = await handler(
+      new Request("http://localhost/api/v10/channels/ch-1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "x" }),
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    expect(res.status).not.toBe(502);
+    expect(((await res.json()) as Record<string, unknown>).proxy).toBe("scream-hole");
+  });
+
+  // The complement, and the one that matters most: an INTERNAL fault must NOT be
+  // labelled an upstream one. An earlier version wrapped the whole router in a
+  // 502, so a cache throw on a cache-only route with no client configured came
+  // back as "upstream Discord request failed" — on a request that never touched
+  // Discord. Because the README tells consumers 502 is transient, a deterministic
+  // internal bug would have been retried forever instead of surfacing.
+  test("an internal fault is a neutral 500, never blamed on Discord", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    cache.getChannels = () => {
+      throw new Error("cache corruption");
+    };
+
+    // No client at all — Discord is definitionally uncontactable on this path.
+    const handler = createHandler(cache, "guild-1", TEST_TTL);
+    const res = await handler(
+      new Request("http://localhost/api/v10/guilds/guild-1/channels"),
+    );
+
+    expect(res.status).toBe(500);
+    expect(res.status).not.toBe(502);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.proxy).toBe("scream-hole");
+    // Must not assert an upstream failure it cannot know occurred.
+    expect(String(body.error)).not.toContain("upstream");
+    expect(String(body.error)).not.toContain("Discord");
+  });
+
+  /**
+   * A net that can tear is not a net. Both guards read `.stack`/`.message` off an
+   * arbitrary thrown value and stringify the result — every one of those steps
+   * runs code the THROWER controls (a getter, a `toString`, a `Symbol.toPrimitive`,
+   * a Proxy trap). An earlier version did the read and interpolation directly in
+   * the catch, and hostile values tore straight through it.
+   *
+   * FIXTURES HERE ARE SELF-VERIFYING, and that is load-bearing. Two ways these
+   * tests have already lied:
+   *
+   *   1. `class E extends Error { get stack() {...} }` never fires — Error
+   *      instances carry an OWN `stack` that shadows a prototype getter. The
+   *      fixture looked adversarial and was inert. Own-property form is required.
+   *   2. Building the value INSIDE the throwing stub is self-masking: if
+   *      construction itself throws, that error propagates exactly like the
+   *      intended one and the assertion passes. The test is then satisfied by
+   *      the very failure it exists to detect.
+   *
+   * So each case carries a `probe` that must demonstrably throw when applied to
+   * the constructed value. The value is built OUTSIDE the stub and the probe is
+   * asserted BEFORE the request. A fixture whose hostility fails to install now
+   * fails the test instead of passing it.
+   *
+   * Cases with `probe: null` are declared INERT on purpose — they exercise the
+   * branch that declines to touch the value at all. They are not hostile and are
+   * labelled so nobody reads a uniformly-adversarial list.
+   */
+  type Hostile = {
+    name: string;
+    make: () => unknown;
+    /** Applied to the built value; MUST throw, proving the hostility is live. */
+    probe: ((v: unknown) => unknown) | null;
+  };
+
+  /** The outer guard reads `.stack`, falls back to `.message`, then stringifies. */
+  const OUTER_GUARD_HOSTILES: Hostile[] = [
+    {
+      name: "own `stack` getter throws",
+      make: () => {
+        const e = new Error("boom");
+        Object.defineProperty(e, "stack", {
+          get() {
+            throw new Error("stack getter exploded");
+          },
+        });
+        return e;
+      },
+      probe: (v) => (v as { stack?: unknown }).stack,
+    },
+    {
+      name: "`stack` is an object whose toString throws",
+      make: () => {
+        const e = new Error("boom");
+        Object.defineProperty(e, "stack", {
+          value: {
+            toString() {
+              throw new Error("toString exploded");
+            },
+          },
+        });
+        return e;
+      },
+      probe: (v) => String((v as { stack?: unknown }).stack),
+    },
+    {
+      // The Symbol.toPrimitive mechanism is reachable through the VALUE of
+      // `.stack`, not through the thrown object — an earlier case aimed it at the
+      // thrown object, where `instanceof Error` is false and the value is never
+      // touched, and a comment claimed it fired. It did not.
+      name: "`stack` is an object whose Symbol.toPrimitive throws",
+      make: () => {
+        const e = new Error("boom");
+        Object.defineProperty(e, "stack", {
+          value: {
+            [Symbol.toPrimitive]() {
+              throw new Error("toPrimitive exploded");
+            },
+          },
+        });
+        return e;
+      },
+      probe: (v) => String((v as { stack?: unknown }).stack),
+    },
+    {
+      name: "`stack` is a null-prototype object (String() throws)",
+      make: () => {
+        const e = new Error("boom");
+        Object.defineProperty(e, "stack", { value: Object.create(null) });
+        return e;
+      },
+      probe: (v) => String((v as { stack?: unknown }).stack),
+    },
+    {
+      name: "no `stack`, and `message` getter throws",
+      make: () => {
+        const e = new Error("boom");
+        Object.defineProperty(e, "stack", { value: undefined });
+        Object.defineProperty(e, "message", {
+          get() {
+            throw new Error("message exploded");
+          },
+        });
+        return e;
+      },
+      probe: (v) => (v as { message?: unknown }).message,
+    },
+    {
+      // Attacks the guard's own machinery: `instanceof` consults getPrototypeOf
+      // on a Proxy, which runs BEFORE any property read.
+      name: "Proxy whose getPrototypeOf throws (breaks `instanceof`)",
+      make: () =>
+        new Proxy(
+          {},
+          {
+            getPrototypeOf() {
+              throw new Error("getPrototypeOf exploded");
+            },
+          },
+        ),
+      probe: (v) => v instanceof Error,
+    },
+    {
+      name: "proxied Error whose get trap throws",
+      make: () =>
+        new Proxy(new Error("boom"), {
+          get() {
+            throw new Error("get trap exploded");
+          },
+        }),
+      probe: (v) => (v as { stack?: unknown }).stack,
+    },
+    {
+      name: "null-prototype thrown value",
+      make: () => Object.create(null),
+      probe: null, // instanceof false → literal substituted → value never touched
+    },
+    {
+      name: "non-Error whose toString throws",
+      make: () => ({
+        toString() {
+          throw new Error("toString exploded");
+        },
+      }),
+      probe: null, // same branch — declines to touch the value
+    },
+  ];
+
+  // Pins the sentence the entire fixture design rests on. Without this it is
+  // folklore in a comment, and the first person who reads "these probes look
+  // redundant" deletes them and silently reopens the self-masking hole.
+  test("an Error's OWN `stack` shadows a prototype getter (why probes exist)", () => {
+    let prototypeGetterFired = false;
+    class ProtoGetter extends Error {
+      get stack(): string {
+        prototypeGetterFired = true;
+        throw new Error("this never runs");
+      }
+    }
+
+    const shadowed = new ProtoGetter("x");
+    // Reading `.stack` hits the instance's OWN property, so the prototype getter
+    // is never consulted — the fixture form that looks adversarial and is inert.
+    expect(() => shadowed.stack).not.toThrow();
+    expect(prototypeGetterFired).toBe(false);
+
+    // The own-property form DOES fire. Every hostile fixture uses this form
+    // because of the line above, not by style preference.
+    let ownGetterFired = false;
+    const own = new Error("x");
+    Object.defineProperty(own, "stack", {
+      get() {
+        ownGetterFired = true;
+        throw new Error("this fires");
+      },
+    });
+    expect(() => own.stack).toThrow();
+    expect(ownGetterFired).toBe(true);
+  });
+
+  describe("the last-resort guard cannot be torn", () => {
+    test.each(OUTER_GUARD_HOSTILES.map((h) => [h.name, h] as const))(
+      "%s still yields a marked 500",
+      async (_name, h) => {
+        const value = h.make();
+        // Proves the fixture is live BEFORE it is used. Without this, a fixture
+        // that failed to install its hostility would pass green.
+        if (h.probe) expect(() => h.probe!(value)).toThrow();
+
+        const cache = createCache(TEST_TTL, TEST_WINDOW);
+        cache.getChannels = () => {
+          throw value;
+        };
+        const handler = createHandler(cache, "guild-1", TEST_TTL);
+
+        // Must not reject — a throw escaping here IS the failure being guarded.
+        const res = await handler(
+          new Request("http://localhost/api/v10/guilds/guild-1/channels"),
+        );
+
+        expect(res.status).toBe(500);
+        expect(((await res.json()) as Record<string, unknown>).proxy).toBe("scream-hole");
+      },
+    );
+  });
+
+  /**
+   * The 502's own logging must not cost us the 502. A throw while DESCRIBING an
+   * upstream failure never produces a bare 500 — the outer guard catches it —
+   * but it downgrades "Discord was unreachable" to "we broke", discarding the
+   * attribution this path exists to provide.
+   *
+   * This guard reads `.message` only (never `.stack`), so its reachable hostile
+   * space differs from the outer guard's and the cases are NOT copied across.
+   * That cross-file claim is pinned by the test directly below — it was
+   * previously asserted in prose with nothing checking it, so adding a `.stack`
+   * read to `forwardUpstream` would have left this rationale silently wrong and
+   * group B under-covered with no failure anywhere.
+   */
+  // A SOURCE-level check, deliberately. The behavioural version does not work:
+  // because `forwardUpstream`'s logging is isolated, a throwing `.stack` getter
+  // would be swallowed and the 502 returned anyway — the test would pass whether
+  // or not the read was added. The isolation that makes the code robust is
+  // exactly what makes the behaviour unable to witness this. So the claim is
+  // checked where it is actually decidable: the source.
+  //
+  // LIMIT, stated adjacent per the rule: this pins that the identifier does not
+  // appear in that function. It does not prove the reachable hostile space is
+  // fully covered — only that the stated reason for group B's shape is still true.
+  test("forwardUpstream reads `.message` only — group B's coverage rationale", async () => {
+    const src = await Bun.file(
+      new URL("../index.ts", import.meta.url).pathname,
+    ).text();
+
+    const start = src.indexOf("async function forwardUpstream(");
+    expect(start).toBeGreaterThan(-1);
+    // Function body ends at the first dedented closing brace at 2-space indent.
+    const end = src.indexOf("\n  }\n", start);
+    expect(end).toBeGreaterThan(start);
+    const body = src.slice(start, end);
+
+    expect(body).toContain("err.message");
+    // If this fails, forwardUpstream grew a `.stack` read: add the stack-hostile
+    // cases to UPSTREAM_HOSTILES before relaxing it.
+    expect(body).not.toContain("err.stack");
+  });
+
+  const UPSTREAM_HOSTILES: Hostile[] = [
+    {
+      name: "Error whose message getter throws",
+      make: () => {
+        const e = new Error("x");
+        Object.defineProperty(e, "message", {
+          get() {
+            throw new Error("message exploded");
+          },
+        });
+        return e;
+      },
+      probe: (v) => (v as { message?: unknown }).message,
+    },
+    {
+      name: "`message` is an object whose toString throws",
+      make: () => {
+        const e = new Error("x");
+        Object.defineProperty(e, "message", {
+          value: {
+            toString() {
+              throw new Error("toString exploded");
+            },
+          },
+        });
+        return e;
+      },
+      probe: (v) => String((v as { message?: unknown }).message),
+    },
+    {
+      name: "Proxy whose getPrototypeOf throws (breaks `instanceof`)",
+      make: () =>
+        new Proxy(
+          {},
+          {
+            getPrototypeOf() {
+              throw new Error("getPrototypeOf exploded");
+            },
+          },
+        ),
+      probe: (v) => v instanceof Error,
+    },
+    {
+      name: "proxied Error whose get trap throws",
+      make: () =>
+        new Proxy(new Error("x"), {
+          get() {
+            throw new Error("get trap exploded");
+          },
+        }),
+      probe: (v) => (v as { message?: unknown }).message,
+    },
+    {
+      name: "null-prototype thrown value",
+      make: () => Object.create(null),
+      probe: null, // instanceof false → literal substituted → value never touched
+    },
+    {
+      name: "non-Error whose toString throws",
+      make: () => ({
+        toString() {
+          throw new Error("toString exploded");
+        },
+      }),
+      probe: null, // same branch
+    },
+  ];
+
+  test.each(UPSTREAM_HOSTILES.map((h) => [h.name, h] as const))(
+    "upstream 502 survives a hostile error value: %s",
+    async (_name, h) => {
+      const value = h.make();
+      if (h.probe) expect(() => h.probe!(value)).toThrow();
+
+      const cache = createCache(TEST_TTL, TEST_WINDOW);
+      const client = mockClient({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        body: {},
+      });
+      client.fetchMessage = async () => {
+        throw value;
+      };
+
+      const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+      const res = await handler(
+        new Request("http://localhost/api/v10/channels/ch-1/messages/111222333444555666"),
+      );
+
+      // 502, not 500 — the attribution must survive describing the failure.
+      expect(res.status).toBe(502);
+      expect(((await res.json()) as Record<string, unknown>).proxy).toBe("scream-hole");
+    },
+  );
+
+  test("a write pass-through failure is also attributable", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const client = mockClient({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: {},
+    });
+    client.sendMessage = async () => {
+      throw new Error("socket hang up");
+    };
+
+    const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+    const res = await handler(
+      new Request("http://localhost/api/v10/channels/ch-1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "x" }),
+      }),
+    );
+
+    expect(res.status).toBe(502);
+    expect(((await res.json()) as Record<string, unknown>).proxy).toBe("scream-hole");
+  });
+});
+
+// The README states that `/health` and `/lease/*` SUCCESSES are deliberately
+// unmarked — Discord serves neither path, so provenance is never in question and
+// stamping them would dilute what the marker means. That was documented with
+// nothing holding it: marking them later would silently make the doc wrong and
+// erode the marker's meaning, which is the whole reason it is trustworthy.
+describe("deliberately unmarked surfaces (#25)", () => {
+  test.each([
+    ["/health", "/health"],
+    ["lease status", "/lease/mic/status?channel=ch-1"],
+  ])("%s success carries no proxy marker", async (_name, path) => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const handler = createHandler(cache, "guild-1", TEST_TTL);
+    const res = await handler(new Request(`http://localhost${path}`));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    // Not an oversight — these paths are off the Discord-impersonating surface.
+    expect(body.proxy).toBeUndefined();
+  });
+});
+
+// The success side of the same provenance question. Body-stamping cannot cover
+// it — a cache read returns a bare Discord-shaped array with nowhere to put a
+// key — so cache reads mark themselves in the HEADERS instead. A response
+// forwarded from Discord carries neither marker, which is what makes "who
+// answered me" decidable for every response on the Discord-impersonating surface.
+describe("proxy-origin success markers (#25)", () => {
+  test("cache-backed reads set X-Cache; forwarded responses never do", async () => {
+    const cache = createCache(TEST_TTL, TEST_WINDOW);
+    const now = Date.now();
+    cache.setChannels("guild-1", [makeChannel("ch-1", "general")]);
+    cache.setMessages("ch-1", [
+      makeMessage(timestampToSnowflake(now - 60_000), "ch-1", "cached"),
+    ]);
+    const client = mockClient({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: makeMessage("111222333444555666", "ch-1", "from discord"),
+    });
+    const handler = createHandler(cache, "guild-1", TEST_TTL, client);
+
+    // Cache-backed reads — proxy-origin, so they mark themselves.
+    for (const path of [
+      "/api/v10/guilds/guild-1/channels",
+      "/api/v10/channels/ch-1/messages?after=0",
+      "/api/v10/channels/ch-99/messages?after=0", // fail-open 200 [] (#16)
+    ]) {
+      const res = await handler(new Request(`http://localhost${path}`));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("X-Cache")).toBeTruthy();
+    }
+
+    // Forwarded from Discord — must carry no proxy marker of either kind.
+    const forwarded = await handler(
+      new Request("http://localhost/api/v10/channels/ch-1/messages/111222333444555666"),
+    );
+    expect(forwarded.status).toBe(200);
+    expect(forwarded.headers.get("X-Cache")).toBeNull();
+    expect(((await forwarded.json()) as Record<string, unknown>).proxy).toBeUndefined();
   });
 });

--- a/tests/poller.test.ts
+++ b/tests/poller.test.ts
@@ -30,6 +30,9 @@ function makeMockClient(
     async createThread() {
       return { ok: true, status: 201, headers: new Headers(), body: {} };
     },
+    async fetchMessage() {
+      return { ok: true, status: 200, headers: new Headers(), body: {} };
+    },
     async listWebhooks() {
       return { ok: true, status: 200, headers: new Headers(), body: [] };
     },
@@ -96,6 +99,9 @@ describe("initialPoll", () => {
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
       },
+      async fetchMessage() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
+      },
       async listWebhooks() {
         return { ok: true, status: 200, headers: new Headers(), body: [] };
       },
@@ -150,6 +156,9 @@ describe("initialPoll", () => {
       },
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async fetchMessage() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
       },
       async listWebhooks() {
         return { ok: true, status: 200, headers: new Headers(), body: [] };
@@ -302,6 +311,9 @@ describe("channel backoff in polling", () => {
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
       },
+      async fetchMessage() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
+      },
       async listWebhooks() {
         return { ok: true, status: 200, headers: new Headers(), body: [] };
       },
@@ -366,6 +378,9 @@ describe("channel backoff in polling", () => {
       },
       async createThread() {
         return { ok: true, status: 201, headers: new Headers(), body: {} };
+      },
+      async fetchMessage() {
+        return { ok: true, status: 200, headers: new Headers(), body: {} };
       },
       async listWebhooks() {
         return { ok: true, status: 200, headers: new Headers(), body: [] };

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -276,6 +276,29 @@ describe("createChannel / createThread — creation POSTs proxied (#18)", () => 
     expect(result.status).toBe(403);
   });
 
+  test("fetchMessage GETs /channels/{id}/messages/{messageId} (#25)", async () => {
+    const { fetch, captured } = urlCapturingFetch(200);
+    const client = createDiscordClient("test-token", fetch);
+
+    const result = await client.fetchMessage("ch-1", "msg-42");
+
+    // The full two-segment path is the whole point — the proxy route this backs
+    // exists because the LIST path alone was all that matched.
+    expect(captured.url).toContain("/channels/ch-1/messages/msg-42");
+    expect(captured.method).toBe("GET");
+    expect(result.status).toBe(200);
+  });
+
+  test("fetchMessage surfaces a Discord 404 verbatim rather than throwing", async () => {
+    const { fetch } = urlCapturingFetch(404);
+    const client = createDiscordClient("test-token", fetch);
+
+    const result = await client.fetchMessage("ch-1", "deleted-1");
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+  });
+
   test("listWebhooks GETs /channels/{id}/webhooks", async () => {
     const { fetch, captured } = urlCapturingFetch(200);
     const client = createDiscordClient("test-token", fetch);


### PR DESCRIPTION
## Summary

`GET /api/v10/channels/{id}/messages/{messageId}` was never routed — the messages regex is `$`-anchored, so the extra path segment fell through to the catch-all 404. Consumers read that 404 as "the message was deleted" and dropped it silently, losing every forwarded message on every host using the proxy. Verified live in production: 43h uptime, 1.2M cache hits, still dropping.

This adds the missing route and removes the ambiguity that made the bug possible.

## Changes

- **`GET /channels/{id}/messages/{messageId}`** — live pass-through, snowflake-guarded, 503 without a client. Deliberately **not** cache-backed: a cache cannot represent a deletion it has not polled, so a cached hit would report an upstream-deleted message as present and invert the caller's deleted-vs-transient discrimination.
- **Catch-all `404` → `501`** with a self-identifying body. A proxy answering 404 for an unrouted path asserts something about an origin resource it never queried, and its body was byte-comparable to Discord's `{"message":"Unknown Message","code":10008}`.
- **`proxyError()` helper** — every proxy-constructed error carries `proxy: "scream-hole"`, stamped structurally so a route added later cannot forget it.
- **Failure attribution** — `502` when Discord was unreachable (retry), `500` when the fault is ours (don't). The 502 is raised only around the call that actually contacts Discord.
- **README** documents the provenance contract: identify a proxy answer by the *presence* of `proxy`, never by the *absence* of Discord's `code`.

## Linked Issues

Closes #25

Follow-up filed: #26 (pre-existing README endpoint-table gaps).

## Test Plan

`./scripts/ci/validate.sh` — `tsc --noEmit` clean, shellcheck 3/3, **156 pass / 0 fail**.

Six code-review passes (0 critical) plus five independent verification passes. Every guarantee comment on the branch is backed by a mutation or carries a stated limit beside it. Mutations run and confirmed red-then-green:

- disabling the route → the #25 regression guard fails
- removing the `proxy` key → 9 tests fail
- bypassing the helper at one site → exactly the row naming it fails
- adding a `proxyError` site without a row → coverage tripwire fails
- reverting the guard isolation → hostile-error tests fail
- moving `onResult` / `writeResponse` inside the upstream try → attribution tests fail (each pinned independently)
- adding a cache to the webhook-list path → live-forward test fails
- stamping `/health` with the marker → unmarked-surface test fails

Hostile-error fixtures are self-verifying: each probes that its hostile member actually executes before the request runs, so a fixture that fails to install its hostility fails the test rather than passing green.

**Not included:** no tag, no deploy. The release tag publishes a floating `latest`, so if production tracks `latest` the tag *is* the deploy — held pending confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G55DQCw6MKFHiCqtNFrr5c