### PR TITLE
chore(release): set version to 1.3.0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import type { Cache } from "./cache";
 import { initialPoll, startPollingLoop, createLogger, createChannelHealth } from "./poller";
 import { claim, release, status, DEFAULT_TTL, type LeaseKind } from "./mic";
 
-const VERSION = "1.2.0";
+const VERSION = "1.3.0";
 const startTime = Date.now();
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scream-hole",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Discord REST API caching proxy — polls once, serves many",
   "type": "module",
   "main": "index.ts",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -107,6 +107,24 @@ function mockClient(
   };
 }
 
+// The two version fields must move together. Nothing enforced that: the /health
+// test below compares the served value against the same constant that produced
+// it, so it is tautological — it proves /health is WIRED to VERSION, which is
+// useful, but it can never catch a missed or half-applied bump. That left the
+// release convention (bdb607a) resting entirely on the author remembering both
+// files, with no automated backstop.
+//
+// LIMIT, stated adjacent: this catches DRIFT BETWEEN the two files. It cannot
+// catch both being bumped to the same wrong value, and it does not know the git
+// tag exists — agreement with `v{VERSION}` is still verified by hand at tag time.
+test("VERSION and package.json agree — a half-applied bump fails here", async () => {
+  const pkg = (await Bun.file(
+    new URL("../package.json", import.meta.url).pathname,
+  ).json()) as { version: string };
+
+  expect(VERSION).toBe(pkg.version);
+});
+
 describe("GET /health", () => {
   test("returns 200 with status ok, uptime, version, and cache stats", async () => {
     const cache = createCache(TEST_TTL, TEST_WINDOW);


### PR DESCRIPTION
## Summary

Bumps `index.ts` `VERSION` and `package.json` to `1.3.0` so the published image reports its own version, ahead of tagging `v1.3.0`. Same re-sync #21 performed for 1.1.0.

**Not cosmetic.** `/health` serves `VERSION`, and production verifies a deploy by reading it. Tagging `v1.3.0` against `VERSION = "1.2.0"` would publish an image reporting `1.2.0`, so `/health` reads identically before and after the deploy — the exact check used to confirm the #25 outage was live would be silently useless, or read as "the deploy did not take."

## Changes

- `index.ts` — `VERSION` → `1.3.0`
- `package.json` — `version` → `1.3.0`
- `tests/index.test.ts` — new guard asserting `VERSION === package.json.version`

## Why the guard

The existing `/health` version test is tautological:

```ts
expect(body.version).toBe(VERSION);
```

It compares the served value against the same constant that produced it. That proves `/health` is *wired* to `VERSION` — a useful invariant — but it can **never** catch a missed or half-applied bump. CI had no backstop on the thing this change exists to get right, so correctness rested entirely on both files being edited together by hand.

**Limit of the new guard, stated here and adjacent to the test:** it catches drift *between the two files*. It cannot catch both being bumped to the same wrong value, and it does not know the git tag exists — three-way agreement with `v{VERSION}` remains a hand check at tag time. Do not read it as covering the tag.

## Version choice

`1.2.0` + #25 → minor, not major. #25 changed the catch-all from `404` to `501`, which is an observable status change — but the old 404 was never a contract a consumer *could* correctly depend on: the README documents it as indistinguishable from Discord's own `404 {"message":"Unknown Message","code":10008}`. Code branching on it was already broken, since it could not tell which layer answered. Fixing an ambiguous signal is not removing a contract. Everything else is additive.

The behavior change is still called out in the v1.3.0 release notes — consumers were not *entitled* to rely on the 404, and should still be *told*.

## Linked Issues

Closes #28

## Test Plan

`./scripts/ci/validate.sh` — tsc clean, shellcheck 3/3, **157 pass / 0 fail**. Trivy: 0 HIGH/CRITICAL.

Guard mutation-verified: bumping `index.ts` alone while leaving `package.json` at the old value fails the new test. Verified independently by the reviewer at `1.3.1`/`1.3.0` — 1 fail.

Full repo sweep confirms no other version-bearing location is stale: `Dockerfile` and `docker-compose.yml` carry no app version, `release.yml` derives `{{version}}` from the git tag, and no test asserts a version literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G55DQCw6MKFHiCqtNFrr5c