### PR TITLE
docs(readme): document every route and guard the quoted error bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,18 +47,64 @@ DISCORD_BOT_TOKEN=your-token DISCORD_GUILD_ID=your-guild-id bun run start
 
 ## Endpoints
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/health` | Health check — status, uptime, version, cache stats |
-| GET | `/api/v10/guilds/{id}/channels` | Cached channel list |
-| GET | `/api/v10/channels/{id}/messages?after=SNOWFLAKE` | Cached messages (`after` required) |
-| GET | `/api/v10/channels/{id}/messages/{messageId}` | Single message — **live**, never cached (see below) |
-| POST | `/api/v10/channels/{id}/messages` | Write pass-through — forwards to Discord |
+Every route is one of three kinds, and the kind is what tells you how stale the
+answer can be:
+
+- **cached** — served from the poller's snapshot; may be stale, carries `X-Cache`
+- **live** — forwarded to Discord on every request; never cached, no `X-Cache`
+- **local** — served by this process; Discord is not involved at all
+
+| Method | Path | Kind | Description |
+|--------|------|------|-------------|
+| GET | `/health` | local | Status, uptime, version, cache stats |
+| GET | `/lease/{mic\|send}/status?channel=ID` | local | Advisory lease state (`channel` required) |
+| POST | `/lease/{mic\|send}/claim` | local | Claim an advisory lease (`channel`, `holder`, optional `ttl_ms`) |
+| POST | `/lease/{mic\|send}/release` | local | Release an advisory lease (`channel`, `holder`) |
+| GET | `/api/v10/guilds/{id}/channels` | cached | Channel list |
+| POST | `/api/v10/guilds/{id}/channels` | live | Create channel — forwarded verbatim |
+| GET | `/api/v10/channels/{id}/messages?after=SNOWFLAKE&limit=N` | cached | Messages (`after` required, `limit` optional); **fails open**, see below |
+| POST | `/api/v10/channels/{id}/messages` | live | Send message — forwarded verbatim, result injected into the cache |
+| GET | `/api/v10/channels/{id}/messages/{messageId}` | live | Single message — deliberately never cached, see below |
+| POST | `/api/v10/channels/{id}/threads` | live | Create thread — forwarded verbatim |
+| GET | `/api/v10/channels/{id}/webhooks` | live | List webhooks — deliberately never cached, see below |
+| POST | `/api/v10/channels/{id}/webhooks` | live | Create webhook — forwarded verbatim |
+| POST | `/api/v10/webhooks/{id}/{token}` | live | Execute webhook — forwarded verbatim, query string (e.g. `?wait=true`) preserved |
+| *any* | anything else | — | `501` — see [Unrouted paths](#unrouted-paths-return-501-not-404) |
+
+Notes on the table:
+
+- **Thread creation** covers the standalone form only. The message-anchored
+  `POST /api/v10/channels/{id}/messages/{id}/threads` is **not** routed and falls
+  through to the 501 catch-all.
+- **Lease methods are exact.** `status` is GET-only; `claim` and `release` are
+  POST-only. Any other method **on those exact paths** returns `405`. An
+  unrecognized lease path — a misspelled action, or a kind other than `mic` /
+  `send` — is not a lease route at all and returns `501` like any other unrouted
+  path. The distinction matters: `405` means "wrong verb, right route", `501`
+  means "this proxy does not serve that path."
+- **`limit` on the messages read** must be a positive integer; anything else is
+  a `400`. Omitting it returns everything cached after `after`.
+- **`limit` is not a pagination cursor, and pairing it with `after` drops
+  messages.** When more messages match than `limit` allows, the **newest** `N`
+  are returned and the older matches — the ones nearest your `after` cursor —
+  are discarded, with no error and no header to say so. A consumer that advances
+  `after` to the newest id it received will never be served the skipped ones.
+  Omit `limit` when consuming with `after`; use it only for "show me the latest
+  N". Documented because the behavior is real, not because it is good — whether
+  it also diverges from Discord's own `after` semantics is an open question,
+  tracked in #30.
+- **Live routes need a bot token.** When no Discord client is configured they
+  return `503` rather than failing at the upstream call.
+- Every **live** response is Discord's status, body, and rate-limit headers
+  verbatim — including Discord's own error bodies. See
+  [Who answered?](#who-answered-every-proxy-originated-error-carries-proxy).
 
 The messages endpoint **fails open**: a quiet, idle, or not-yet-cached channel
 returns `200 []` (never 404), so consumers treat it as "nothing new" instead of
-falling back to Discord directly and storming its rate limit. Any `after` value
-is accepted, including `after=0` ("everything cached").
+falling back to Discord directly and storming its rate limit. Any *snowflake*
+`after` is accepted, including `after=0` ("everything cached") — an `after`
+older than the cache window is clamped to the window start rather than returning
+empty. A non-numeric `after` is a `400`; the parameter is required.
 
 Single-message fetch is deliberately **not** cache-backed. Callers use it to tell
 a deleted message from a transient failure, and a cache cannot represent a
@@ -66,6 +112,12 @@ deletion it has not yet polled — so a cached hit would report a message delete
 upstream as still present, inverting exactly the distinction the caller is
 making. It forwards live to Discord and returns Discord's status and body
 verbatim, including a genuine `404 {"message":"Unknown Message","code":10008}`.
+
+Webhook listing is **not** cache-backed either, for a different reason: each
+webhook's `token` is in the response body, and a token is a credential — caching
+one would serve a revoked or rotated token as current. It forwards live so that
+consumers can reuse an existing webhook rather than creating another and
+exhausting Discord's per-channel cap.
 
 ### Unrouted paths return 501, not 404
 

--- a/cache.ts
+++ b/cache.ts
@@ -43,7 +43,17 @@ export interface Cache {
   /**
    * Get messages for a channel filtered by `after` snowflake.
    * Returns undefined if the channel is not cached at all.
-   * Returns empty array if `after` is older than the cache window.
+   *
+   * An `after` older than the cache window is CLAMPED to the window start, so
+   * everything cached is returned — it does NOT return an empty array. (That
+   * was this docstring's previous claim and it described pre-clamp behavior;
+   * the README now publishes the clamp as a contract, so do not "restore" the
+   * empty-array behavior without changing both.)
+   *
+   * `limit` returns the NEWEST n matches, discarding older ones nearest the
+   * `after` cursor — see the caveat in README.md's endpoint notes. Whether that
+   * matches Discord's own `after`+`limit` ordering is UNMEASURED; see #30
+   * before trusting the "matching Discord API behavior" note at the slice.
    */
   getMessages(
     channelId: string,

--- a/tests/doc-drift.test.ts
+++ b/tests/doc-drift.test.ts
@@ -1,0 +1,178 @@
+import { test, expect, describe } from "bun:test";
+
+/**
+ * Guards against the README and the code drifting apart.
+ *
+ * #25 added a provenance contract to the README that quotes exact response
+ * bodies, and consumers are told to match on them. Nothing enforced that the
+ * quotes were real: renaming an error string in `index.ts` left the README
+ * silently wrong, with no test anywhere going red. That is the same drift class
+ * #26 exists to fix on the endpoint table, one level down — a doc making a
+ * promise the code is free to break.
+ *
+ * The check runs README -> source, never the reverse. The README documents a
+ * deliberate SUBSET of the proxy's errors (the catch-all and the two
+ * attribution failures); asserting every `proxyError()` site were documented
+ * would red the suite for errors nobody ever intended to publish.
+ */
+
+const README = await Bun.file(new URL("../README.md", import.meta.url).pathname).text();
+const SOURCE = await Bun.file(new URL("../index.ts", import.meta.url).pathname).text();
+
+/** An `"error": "…"` key/value, wherever it appears. */
+const ERROR_KEY = /"error"\s*:\s*"((?:[^"\\]|\\.)*)"/;
+
+/**
+ * Every error body the README quotes, keyed on `"error"` appearing ANYWHERE in
+ * the quote rather than as the first key with a status glued to the brace.
+ *
+ * That looseness is deliberate and was a real bug in the first version of this
+ * file. The strict form silently missed two shapes a future author would write
+ * without a second thought — `{"proxy": …, "error": …}` (keys swapped) and a
+ * body mentioned in prose with no adjacent status — and the vacuity floor below
+ * could not catch either, because the three existing quotes satisfy it on their
+ * own. A guard whose blind spot is "the next quote somebody adds" is worse than
+ * no guard: the README grows an unchecked claim while the suite reports green.
+ *
+ * `"error"` is still the right discriminator for scanning the whole file: a
+ * proxy body has `error` + `proxy`, a Discord body has `message` + `code`. The
+ * genuine `404 {"message":"Unknown Message","code":10008}` the README also
+ * quotes is therefore not picked up — correctly, since it is Discord's string
+ * and not ours to keep in sync.
+ */
+const documentedBodies = [...README.matchAll(new RegExp(ERROR_KEY, "g"))].map((m) => m[1]!);
+
+/**
+ * The subset of those quotes that also carry a status code, so the status can
+ * be checked too. Matches a braced group preceded by a 3-digit status and then
+ * looks for `error` INSIDE it — order-insensitive, unlike the first version.
+ *
+ * Not every quote can be status-paired (prose may cite a body without one), so
+ * this is a subset by design; existence for all of them is covered above.
+ */
+const documentedPairs = [...README.matchAll(/(\d{3})\s*(\{[^}]*\})/g)].flatMap((m) => {
+  const error = m[2]!.match(ERROR_KEY);
+  return error ? [{ status: Number(m[1]), error: error[1]! }] : [];
+});
+
+/**
+ * `{status, error}` pairs actually constructed by `proxyError()` in `index.ts`.
+ *
+ * `\s*` between the tokens rather than a single-line match: one call site (the
+ * `after` 400) wraps its arguments across three lines, and a line-anchored
+ * regex would silently omit it — a miss here weakens the check without failing
+ * it, so the extractor is written to tolerate the formatting the file actually
+ * uses. The optional trailing comma is for that same wrapped site.
+ *
+ * The `function proxyError(error: string, ...)` definition does not match (no
+ * quote follows the paren), nor do the prose mentions of `proxyError()` in the
+ * doc comments.
+ */
+const constructed = [
+  ...SOURCE.matchAll(/proxyError\(\s*"((?:[^"\\]|\\.)*)"\s*,\s*(\d+)\s*,?\s*\)/g),
+].map((m) => ({ status: Number(m[2]), error: m[1]! }));
+
+describe("README quotes real response bodies (#26)", () => {
+  // Vacuity guard, and the reason it comes first: the two pairing tests below
+  // each loop over one of the two collections, so if the provenance section
+  // were deleted or reworded past recognition, that collection would be empty
+  // and its test would pass over an empty loop — green, while the thing it
+  // guards had vanished. A silent pass is the failure mode this file exists to
+  // prevent, so it is checked explicitly.
+  //
+  // BOTH collections are floored, not just the first. An earlier version floored
+  // only `documentedBodies`, which left the status half — the half with
+  // consequences, since the README's retry guidance keys off the status —
+  // able to go vacuous on its own: move the statuses out of the quoted braces
+  // (a status column in the failure table, or "returns 502 with body `{…}`")
+  // and `documentedPairs` empties while the floor above stays satisfied.
+  //
+  // A floor, not an exact count: WHICH errors the README publishes is an
+  // editorial choice, and documenting a fourth should not red the suite. The
+  // three are the 501 catch-all and the 502/500 attribution pair from #25.
+  test("the README still quotes proxy-originated bodies at all", () => {
+    expect(documentedBodies.length).toBeGreaterThanOrEqual(3);
+    expect(documentedPairs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("the extractor finds the proxyError call sites", () => {
+    // Companion vacuity guard for the other side. If a refactor renamed the
+    // helper or changed its signature, `constructed` would empty out and every
+    // pairing below would fail — but with a confusing "not found" for each
+    // string rather than the real cause, which is stated here instead.
+    expect(constructed.length).toBeGreaterThanOrEqual(documentedBodies.length);
+  });
+
+  test("every body the README quotes is really constructed by the proxy", () => {
+    for (const error of documentedBodies) {
+      expect(
+        constructed.some((c) => c.error === error),
+        `README quotes an error no proxyError() call constructs: "${error}"`,
+      ).toBe(true);
+    }
+  });
+
+  // Split from the existence check above because the two failures mean
+  // different things: a missing string is a renamed error, a mismatched status
+  // is a changed contract — and the README tells consumers whether to RETRY
+  // based on that status, so it is the half with consequences.
+  test("every quoted status matches EVERY site that constructs that body", () => {
+    for (const pair of documentedPairs) {
+      const sites = constructed.filter((c) => c.error === pair.error);
+      expect(sites.length, `no proxyError() call constructs "${pair.error}"`).toBeGreaterThan(0);
+      // `filter` + all-must-agree, not `find`. With `find` this asserted only
+      // that SOME site paired correctly, while the limits below claimed the
+      // quoted body "pairs with its status" — an overclaim, and reachable:
+      // "Write pass-through is not configured (no Discord client)" is
+      // constructed at two sites. They agree on 503 today and neither is
+      // quoted, so there was no live defect — but the check would have gone
+      // green on a future divergence, which is what made it worth changing.
+      for (const site of sites) {
+        expect(
+          site.status,
+          `README documents "${pair.error}" as ${pair.status}, a call site returns ${site.status}`,
+        ).toBe(pair.status);
+      }
+    }
+  });
+});
+
+/**
+ * LIMITS — stated adjacent, per the rule this repo applies to its other
+ * source-derived checks. A tripwire a reader over-trusts is worse than none.
+ *
+ *  - It proves the STRINGS still exist and, where a status is quoted alongside,
+ *    that every site constructing that string uses it. It says nothing about
+ *    whether the documented SEMANTICS are still accurate. Changing WHEN a 502
+ *    is raised — the exact defect #25 was about — passes this check untouched.
+ *    That claim is guarded behaviourally in tests/index.test.ts ("upstream
+ *    failure is attributable"), not here.
+ *  - A quote with no status adjacent to it gets its string checked but not its
+ *    status. There is nothing to compare against, so this is a real gap rather
+ *    than an oversight — prefer quoting `<status> {…}` so both halves apply.
+ *  - It cannot see a route that returns an undocumented error, by design (see
+ *    the header): README -> source only.
+ *  - The SOURCE extractor reads double-quoted literals only. The uncached-guild
+ *    404 uses a template literal and is therefore invisible to it. That is safe
+ *    today because the README does not quote it, and safe tomorrow in the right
+ *    direction: quoting it would make the existence test FAIL loudly rather than
+ *    pass silently. Fix that by extending the extractor, never by deleting the
+ *    quote. The README extractor has no equivalent blind spot ON THE EXISTENCE
+ *    CHECK — `documentedBodies` finds an `"error"` key anywhere, which is why
+ *    it replaced the strict version that missed swapped keys silently. The
+ *    status check is narrower: `documentedPairs` stops its braced group at the
+ *    first `}`, so a quoted body whose `"error"` key appears AFTER a nested
+ *    object would have its string checked but not its status. A nested object
+ *    after the `"error"` key is harmless — the truncated group still contains
+ *    the key, so the pair still forms. Unreachable either way today, since
+ *    `proxyError` only ever emits a flat `{error, proxy}`; recorded rather than
+ *    fixed because the fix would be speculative. Stated this narrowly on
+ *    purpose: a limit described more broadly than it is reads as noise to the
+ *    next person who tests it, and then none of these bullets get believed.
+ *  - Nothing here checks the endpoint TABLE against the router. A row naming a
+ *    path that does not exist still passes, and so does a route added without a
+ *    row. That guard is a behavioural probe of the handler rather than a text
+ *    match, so it is a different mechanism, not an extension of this one; #26
+ *    scoped it out deliberately and it is tracked in #31. The table was verified
+ *    against the router BY HAND at #26 and has no standing check until then.
+ */


### PR DESCRIPTION
## Summary

The README endpoint table documented 5 of the proxy's 13 route behaviors. The gap predates #25 — it accumulated as #15/#19/#24 shipped routes without touching the table. This closes it, and adds a source-derived guard for the provenance contract #25 wrote into the README.

## Changes

- **`README.md`** — endpoint table rewritten. Adds the lease routes, `POST guilds/{id}/channels`, `POST channels/{id}/threads`, `GET`+`POST channels/{id}/webhooks`, `POST webhooks/{id}/{token}`, and the 501 catch-all. New **Kind** column (cached / live / local), because the kind is what tells a consumer how stale an answer can be. States *why* each non-cached read is non-cached: single-message fetch so a cache cannot report a deleted message as present; webhook list because the body carries a credential.
- **`tests/doc-drift.test.ts`** (new) — asserts every error body the README quotes is really constructed by a `proxyError()` call in `index.ts`, at the matching status, at *every* site that constructs it. The README quotes exact bodies and tells consumers to match on them; nothing enforced that the quotes were real.
- **`cache.ts`** — comment only, no behavior. The `getMessages` docstring claimed an `after` older than the cache window returns an empty array; the clamp at `:150-156` does the opposite, and the stale claim contradicted a line this PR publishes.

## Linked Issues

Closes #26

Follow-ups filed, not addressed here:
- #30 — `limit`+`after` semantics vs Discord (open question, not a defect claim)
- #31 — behavioural guard for the endpoint table itself

## Test Plan

What was actually run:

- `./scripts/ci/validate.sh` — tsc clean, shellcheck 3 files OK, **161/161 tests**
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings
- **The new guard was mutation-tested in four directions rather than trusted green**, each restored by content diff (not mtime):
  - renamed an error string in `index.ts` → red
  - diverged the status at one of two sites sharing a string → red (and verified `.find()` would have reported PASS here, which is why the check uses `filter()`)
  - added a swapped-key README quote `{"proxy": …, "error": …}` of a nonexistent error → red (**passed green** under the first version of the extractor)
  - moved statuses out of the quoted braces → red on the second vacuity floor
- All 14 table rows hand-traced to their route matcher in `index.ts`, both directions. The 503-without-client claim verified for all 7 live routes individually.

## Review

Three rounds, nine findings, all fixed, zero deferred. Round 2 caught that the README-side extractor matched `"error"` only as the *first* key — a future quote written `{"proxy": …, "error": …}` would have gone unchecked while the vacuity floor stayed satisfied. Fixed by making the extractor order-insensitive rather than by documenting the hole.

## Known gap

The endpoint table itself has **no standing check** — it was verified by hand here. Stated explicitly in the test file's LIMITS block and tracked in #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G55DQCw6MKFHiCqtNFrr5c