### PR TITLE
fix(release): stop a pre-release from moving the latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,38 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
+          # `latest` is deliberately ABSENT here. Do not add it back.
+          #
+          # metadata-action defaults to `flavor: latest=auto` (src/flavor.ts
+          # Transform), which publishes `latest` for a stable semver tag and
+          # withholds it from a pre-release — see the action README's
+          # "Latest tag" section.
+          #
+          # An explicit `type=raw,value=latest` does NOT override that
+          # decision, it BYPASSES it. Under `auto`, procRaw hands `false`
+          # to setVersion (src/meta.ts):
+          #
+          #   Meta.setVersion(version, vraw,
+          #     this.flavor.latest == 'auto' ? false : ...)
+          #
+          # so a raw entry can never make `latest` true. What it does is
+          # emit the literal string `latest` as a tag of its own, on every
+          # v* ref — `v1.4.0-rc1` included. That is what
+          # `docker run ...:latest` would then serve, and README.md's Quick
+          # Start tells every reader to run exactly that.
+          #
+          # Stated precisely because the wrong mechanism mispredicts:
+          # `type=raw,value=latest,enable=false` would NOT suppress
+          # auto-latest (getVersion skips disabled entries and the flavor
+          # is untouched), and reordering this list changes nothing —
+          # entries are sorted by priority before evaluation, descending
+          # (src/tag.ts). See docker/metadata-action#593, which exists to
+          # document this exact distinction.
+          #
+          # Removing the line IS the fix (#33). The safe default was always
+          # in effect; the explicit entry bypassed it.
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml` declared `type=raw,value=latest` with no `enable=` condition, so it emitted the literal tag `latest` on **every** `v*` ref — a pre-release included. `README.md:14` documents `docker run ghcr.io/wave-engineering/scream-hole:latest` as the Quick Start entry point, so publishing `v1.4.0-rc1` would have made a pre-release what every reader of our own docs pulls.

## Changes

- Removed `type=raw,value=latest` from the `docker/metadata-action` tag list. That restores the action's default `flavor: latest=auto`, which publishes `latest` for a stable semver tag and withholds it from a pre-release.
- Added a comment stating the **mechanism**, so re-adding the line is a deliberate act rather than an accident.

The explicit entry never *overrode* `latest=auto` — it **bypassed** it. Under `auto`, `procRaw` hands `false` to `setVersion` (`src/meta.ts`), so a raw entry can never make `latest` true; it simply adds the literal string as a tag of its own. The distinction matters because the wrong mechanism mispredicts: it implies `type=raw,value=latest,enable=false` would suppress auto-latest, which it would not.

## Linked Issues

**Refs #33 — deliberately not `Closes`.** #33's acceptance criteria include a post-merge behavioural proof that cannot run until this lands. The issue stays open until it does.

## Test Plan

What was actually run:

- `./scripts/ci/validate.sh` — tsc clean, shellcheck 3 files OK, 161/161 tests
- `yamllint -d relaxed` on the workflow — clean
- Structural assertion: the parsed `tags:` value is exactly `['type=semver,pattern={{version}}']` and no `flavor` key is present, so `latest=auto` applies
- `trivy fs --scanners vuln --severity HIGH,CRITICAL` — 0 findings

**Registry ground truth** (settles the over-deletion criterion empirically rather than by argument):

```
1.3.0 → ["1.3.0", "latest"]   ← latest is actively published, points here
1.2.0 → ["1.2.0"]   1.1.0 → ["1.1.0"]   0.2.1 → ["0.2.1"]
```

So `latest` **must keep being published** — removing it outright would be a real regression. Also: every tag ever cut is stable semver, so no pre-release has ever been published and this defect has never actually fired. Latent, as filed.

### Not behaviourally tested pre-merge — by design

The proof is "push a pre-release, observe `latest` does not move." Running that **before** the fix would itself move `latest` to a pre-release in the registry production now reads. Confirming the bug by triggering it is the one thing we cannot do here, so verification is gated to post-merge.

### Post-merge proof — both halves required

1. A pre-release tag publishes `{{version}}` and does **not** move `latest`.
2. The **next stable tag does** move `latest` again.

Half 2 is the one that catches an over-deletion regression. A deletion-shaped fix verified only by "the bad thing stopped happening" cannot distinguish *fixed* from *over-deleted* — both look identical on the first test.

## Review

Two rounds. **Zero findings on the code change**; all three findings were in the comment written about it — a fabricated quotation, a wrong causal mechanism, and a correctly-transcribed citation from a section about something else. Every claim in the final comment cites a file and line opened directly: `src/flavor.ts:14`, `src/meta.ts:340`, `src/tag.ts:69-77`, upstream README §"Latest tag", `README.md:14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G55DQCw6MKFHiCqtNFrr5c